### PR TITLE
Bump Camel to 2.17.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     depends_on:
       - base-java
     environment:
-      - FCREPO_BASEURL=fcrepo.docker.local/rest
+      - FCREPO_BASEURL=fcrepo.docker.local/fcrepo/rest
       - JMS_BROKERURL=tcp://fcrepo.docker.local:61616
       - TRIPLESTORE_BASEURL=fuseki.docker.local:3030/fcrepo-triple-index/update
       - ERROR_MAMXREDELIVERIES=100000
@@ -90,7 +90,8 @@ services:
     environment:
       - APIX_REST_PORT=80
       - APIX_REST_HOST=0.0.0.0
-      - FCREPO_BASEURL=fcrepo.docker.local/rest
+      - APIX_REST_PROXY=/fcrepo
+      - FCREPO_BASEURL=fcrepo.docker.local/fcrepo
 
   go-proxy:
     build: proof-of-concept/go-proxy/target
@@ -105,6 +106,7 @@ services:
       - "8082:80"
     environment:
       - PROXY_ADDR=fcrepo.docker.local
+      - PROXY_PATH=/
       - BIND_ADDR=:80
 
 # Tools & Utilities

--- a/docker/services/fcrepo/Dockerfile
+++ b/docker/services/fcrepo/Dockerfile
@@ -15,6 +15,6 @@ CMD mkdir -p ${DATA_DIR} && \
     java -Dfcrepo.home=${DATA_DIR} \
     -jar ${APPS}/fcrepo-webapp-${FCREPO_VERSION}-jetty-console.jar \
     --port ${FCREPO_PORT} \
+    --contextPath /fcrepo \
     --headless 2>&1 \
-    --contextPath /fcrepo
     | tee -a ${DATA_DIR}/fcrepo.log

--- a/docker/services/fcrepo/Dockerfile
+++ b/docker/services/fcrepo/Dockerfile
@@ -16,4 +16,5 @@ CMD mkdir -p ${DATA_DIR} && \
     -jar ${APPS}/fcrepo-webapp-${FCREPO_VERSION}-jetty-console.jar \
     --port ${FCREPO_PORT} \
     --headless 2>&1 \
+    --contextPath /fcrepo
     | tee -a ${DATA_DIR}/fcrepo.log

--- a/proof-of-concept/amherst-apix/pom.xml
+++ b/proof-of-concept/amherst-apix/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <project.copyrightYear>2015</project.copyrightYear>
     <activemq.version>5.11.1</activemq.version>
-    <camel.version>2.17.0</camel.version>
+    <camel.version>2.17.1</camel.version>
     <commons-lang.version>3.4</commons-lang.version>
     <commons-io.version>2.4</commons-io.version>
     <derby.version>10.11.1.1</derby.version>


### PR DESCRIPTION
Bump Amherst POC to Camel 2.17.1, also adjust context paths so that URIs are correct when viewing Fedora through amherst-apix.  Addresses #26
