### PR TITLE
Enabling Travis for sanity-check builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+# 'install' necessary to generate artifacts used by pax exam 
+# - this is the default value assigned by Travis, but included for clarity
+install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+script: mvn verify
+jdk:
+- oraclejdk8
+after_failure:
+- cat fcrepo-api-x-integration/target/test-classes/cfg/*
+- cat fcrepo-api-x-integration/target/failsafe-reports/*.txt

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/RepositoryExtensionBindingIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/RepositoryExtensionBindingIT.java
@@ -133,7 +133,7 @@ public class RepositoryExtensionBindingIT implements KarafIT {
 
         if (!ontologyRegistry.contains(TEST_ONTOLOGY_IRI)) {
             ontologyRegistry.put(testResource(
-                    "ontologies/RemWithOrderedAggregation.ttl"));
+                    "ontologies/ReMWithOrderedAggregation.ttl"));
         }
 
         if (extensionRegistry.list().isEmpty()) {
@@ -182,7 +182,7 @@ public class RepositoryExtensionBindingIT implements KarafIT {
 
         // Put in an ontology that doesn't import ORE or PCDM
         ontologyRegistry.put(testResource(
-                "ontologies/RemWithOrderedAggregation_noImport.ttl"));
+                "ontologies/ReMWithOrderedAggregation_noImport.ttl"));
 
         // Now put in an extension that binds to a class from that ontology
         final URI extensionURI = extensionRegistry.put(testResource(

--- a/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.registry.http.cfg
+++ b/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.registry.http.cfg
@@ -1,2 +1,2 @@
-timeout.socket.ms = 1000
+timeout.socket.ms = 10000
 role = base


### PR DESCRIPTION
Includes a vanilla `travis.yml` which performs a `mvn verify` using Oracle JDK 8.
- https://travis-ci.org/fcrepo4-labs/fcrepo-api-x

Travis is configured to build PRs and on repository pushes.
Builds will start when `.travis.yml` is committed to `fcrepo-api-x`
No state is being kept between builds.
