### PR TITLE
Intercepting service routing

### DIFF
--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/InterceptingModalityIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/InterceptingModalityIT.java
@@ -24,9 +24,12 @@ import java.net.URI;
 
 import javax.inject.Inject;
 
+import org.fcrepo.apix.model.components.ExtensionRegistry;
 import org.fcrepo.apix.model.components.Routing;
+import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoResponse;
 
+import org.apache.camel.Exchange;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,10 +41,13 @@ import org.ops4j.pax.exam.junit.PaxExam;
  * @author apb@jhu.edu
  */
 @RunWith(PaxExam.class)
-public class InterceptingModalityIT extends ServiceExposingTest implements KarafIT {
+public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT {
 
     @Inject
     Routing routing;
+
+    @Inject
+    ExtensionRegistry extensionRegistry;
 
     @Rule
     public TestName name = new TestName();
@@ -61,8 +67,10 @@ public class InterceptingModalityIT extends ServiceExposingTest implements Karaf
         KarafIT.createContainers();
     }
 
+    // Verify that a 'link' header pointing to the service document is present
     @Test
     public void serviceLinkHeaderTest() throws Exception {
+
         final URI object = client.post(objectContainer).slug(testMethodName()).perform().getLocation();
 
         final FcrepoResponse response = client.get(routing.interceptUriFor(object)).perform();
@@ -70,4 +78,29 @@ public class InterceptingModalityIT extends ServiceExposingTest implements Karaf
         assertEquals(1, response.getLinkHeaders("service").size());
         assertEquals(routing.serviceDocFor(object), response.getLinkHeaders("service").get(0));
     }
+
+    // Verify that if an intercepting extension throws a 4xx code, it aborts the request and returns service response.
+    @Test
+    public void incomingInterceptRespomseCodeTest() throws Exception {
+        registerExtension(testResource("objects/extension_InterceptingModalityIT.ttl"));
+
+        registerService(testResource("objects/service_InterceptingServiceIT.ttl"));
+
+        final String LOCATION = "http://example.org/Location";
+        final int RESPONSE_CODE = 418;
+
+        responseFromService.setHeader(Exchange.HTTP_RESPONSE_CODE, RESPONSE_CODE);
+        responseFromService.setHeader("Location", LOCATION);
+
+        final URI objectContainer_intercept = routing.interceptUriFor(objectContainer);
+
+        final URI object = postFromTestResource("objects/object_InterceptingServiceIT.ttl",
+                objectContainer_intercept);
+
+        final FcrepoResponse response = FcrepoClient.client().build().get(object).perform();
+
+        assertEquals(RESPONSE_CODE, response.getStatusCode());
+        assertEquals(LOCATION, response.getHeaderValue("Location"));
+    }
+
 }

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/InterceptingModalityIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/InterceptingModalityIT.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.integration;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+
+import javax.inject.Inject;
+
+import org.fcrepo.apix.model.components.Routing;
+import org.fcrepo.client.FcrepoResponse;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+/**
+ * @author apb@jhu.edu
+ */
+@RunWith(PaxExam.class)
+public class InterceptingModalityIT extends ServiceExposingTest implements KarafIT {
+
+    @Inject
+    Routing routing;
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Override
+    public String testClassName() {
+        return InterceptingModalityIT.class.getSimpleName();
+    }
+
+    @Override
+    public String testMethodName() {
+        return name.getMethodName();
+    }
+
+    @BeforeClass
+    public static void init() throws Exception {
+        KarafIT.createContainers();
+    }
+
+    @Test
+    public void serviceLinkHeaderTest() throws Exception {
+        final URI object = client.post(objectContainer).slug(testMethodName()).perform().getLocation();
+
+        final FcrepoResponse response = client.get(routing.interceptUriFor(object)).perform();
+
+        assertEquals(1, response.getLinkHeaders("service").size());
+        assertEquals(routing.serviceDocFor(object), response.getLinkHeaders("service").get(0));
+    }
+}

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafIT.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.apix.integration;
 
+import static org.apache.commons.io.FilenameUtils.getBaseName;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
@@ -202,7 +203,7 @@ public interface KarafIT {
         try (final WebResource object = testResource(filePath);
                 final FcrepoResponse response = client.post(intoContainer)
                         .body(object.representation(), object.contentType())
-                        .slug(testMethodName())
+                        .slug(String.format("%s_%s", testMethodName(), getBaseName(filePath)))
                         .perform()) {
             return response.getLocation();
         }

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceBasedTest.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceBasedTest.java
@@ -18,41 +18,61 @@
 
 package org.fcrepo.apix.integration;
 
+import static org.fcrepo.apix.model.Ontologies.Service.CLASS_SERVICE_INSTANCE;
+import static org.fcrepo.apix.model.Ontologies.Service.PROP_HAS_ENDPOINT;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Inject;
+
+import org.fcrepo.apix.model.WebResource;
+import org.fcrepo.apix.model.components.ExtensionRegistry;
+import org.fcrepo.apix.model.components.ServiceRegistry;
+import org.fcrepo.apix.model.components.Updateable;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Message;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultMessage;
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.osgi.framework.BundleContext;
 
 /**
- * Test which exposes an HTTP service; implemented by camel-jetty
+ * Test base class which exposes an HTTP service; implemented by camel-jetty
  *
  * @author apb@jhu.edu
  */
-public class ServiceExposingTest {
+public abstract class ServiceBasedTest implements KarafIT {
 
     static final protected String serviceEndpoint = "http://127.0.0.1:" + System.getProperty(
             "services.dynamic.test.port") +
             "/TestService";
 
     @Inject
-    CamelContext cxt;
+    private CamelContext cxt;
+
+    @Inject
+    private ExtensionRegistry extensionRegistry;
+
+    @Inject
+    private ServiceRegistry serviceRegistry;
+
+    @Inject
+    BundleContext bundleContext;
 
     protected final Message responseFromService = new DefaultMessage();
 
     protected final Message requestToService = new DefaultMessage();
 
+    @Override
     public List<Option> additionalKarafConfig() {
         final MavenArtifactUrlReference testBundle = maven()
                 .groupId("org.fcrepo.apix")
@@ -67,18 +87,49 @@ public class ServiceExposingTest {
         cxt.addRoutes(createRouteBuilder());
     }
 
+    protected URI registerService(final WebResource service) throws Exception {
+        // Register the service
+        final URI serviceURI = serviceRegistry.put(service);
+
+        // Register the test service instance endpoint (run by the camel route in this IT)
+        client.patch(serviceURI).body(
+                IOUtils.toInputStream(
+                        String.format("INSERT {?instance <%s> <%s> .} WHERE {?instance a <%s> .}",
+                                PROP_HAS_ENDPOINT, serviceEndpoint, CLASS_SERVICE_INSTANCE), "UTF-8")).perform();
+
+        update();
+
+        return serviceURI;
+    }
+
+    protected URI registerExtension(final WebResource extension) throws Exception {
+        final URI extensionURI = extensionRegistry.put(extension);
+
+        update();
+
+        return extensionURI;
+    }
+
+    private void update() throws Exception {
+
+        bundleContext.getServiceReferences(Updateable.class, null).stream()
+                .map(bundleContext::getService)
+                .forEach(Updateable::update);
+    }
+
     protected RoutesBuilder createRouteBuilder() throws Exception {
+
         return new RouteBuilder() {
 
             @Override
             public void configure() throws Exception {
                 from("jetty:" + serviceEndpoint +
-                        "?matchOnUriPrefix=true").process(ex -> {
-                            ex.getOut().copyFrom(responseFromService);
-                            requestToService.copyFrom(ex.getIn());
-                        });
+                        "?matchOnUriPrefix=true")
+                                .process(ex -> {
+                                    ex.getOut().copyFrom(responseFromService);
+                                    requestToService.copyFrom(ex.getIn());
+                                });
             }
         };
     }
-
 }

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceExposingTest.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceExposingTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.integration;
+
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Message;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.impl.DefaultMessage;
+import org.junit.Before;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+
+/**
+ * Test which exposes an HTTP service; implemented by camel-jetty
+ *
+ * @author apb@jhu.edu
+ */
+public class ServiceExposingTest {
+
+    static final protected String serviceEndpoint = "http://127.0.0.1:" + System.getProperty(
+            "services.dynamic.test.port") +
+            "/TestService";
+
+    @Inject
+    CamelContext cxt;
+
+    protected final Message responseFromService = new DefaultMessage();
+
+    protected final Message requestToService = new DefaultMessage();
+
+    public List<Option> additionalKarafConfig() {
+        final MavenArtifactUrlReference testBundle = maven()
+                .groupId("org.fcrepo.apix")
+                .artifactId("fcrepo-api-x-test")
+                .versionAsInProject();
+        return Arrays.asList(mavenBundle(testBundle));
+        // return Arrays.asList(features(camelRepo, "camel-test"));
+    }
+
+    @Before
+    public void start() throws Exception {
+        cxt.addRoutes(createRouteBuilder());
+    }
+
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+
+            @Override
+            public void configure() throws Exception {
+                from("jetty:" + serviceEndpoint +
+                        "?matchOnUriPrefix=true").process(ex -> {
+                            ex.getOut().copyFrom(responseFromService);
+                            requestToService.copyFrom(ex.getIn());
+                        });
+            }
+        };
+    }
+
+}

--- a/fcrepo-api-x-integration/src/test/resources/objects/extension_InterceptingModalityIT.ttl
+++ b/fcrepo-api-x-integration/src/test/resources/objects/extension_InterceptingModalityIT.ttl
@@ -1,0 +1,5 @@
+@prefix apix:<http://fedora.info/definitions/v4/api-extension#> .
+
+<> a apix:Extension;
+    apix:bindsTo <test:InterceptingModalityIT#object> ;
+    apix:consumesService <http://example.org/InterceptingServiceIt/service> .

--- a/fcrepo-api-x-integration/src/test/resources/objects/object_InterceptingServiceIT.ttl
+++ b/fcrepo-api-x-integration/src/test/resources/objects/object_InterceptingServiceIT.ttl
@@ -1,0 +1,1 @@
+<> a <test:InterceptingModalityIT#object> .

--- a/fcrepo-api-x-integration/src/test/resources/objects/service_InterceptingServiceIT.ttl
+++ b/fcrepo-api-x-integration/src/test/resources/objects/service_InterceptingServiceIT.ttl
@@ -1,0 +1,16 @@
+@prefix svc:<http://fedora.info/definitions/v4/service#> .
+@prefix ore:<http://www.openarchives.org/ore/terms/> .
+
+<> ore:describes <#instances> .
+
+<#service> a svc:Service;
+    svc:canonical <http://example.org/InterceptingServiceIt/service>;
+    svc:hasServiceInstanceRegistry <#instanceRegistry> .
+
+<#instanceRegistry> a svc:ServiceInstanceRegistry;
+    svc:hasServiceInstance <#instances> .
+
+<#instances> a svc:ServiceInstance;
+    svc:isServiceInstanceOf <#service> .
+
+    

--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/JenaServiceRegistry.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/JenaServiceRegistry.java
@@ -67,10 +67,13 @@ public class JenaServiceRegistry extends WrappingRegistry implements ServiceRegi
 
     @Override
     public void update() {
+
+        // Map canonical URI to service resource. If multiple service resources
+        // indicate the same canonical URI, pick one arbitrarily.
         final Map<URI, URI> canonical = list().stream()
                 .map(this::getService)
                 .filter(s -> s.canonicalURI() != null)
-                .collect(Collectors.toMap(s -> s.canonicalURI(), s -> s.uri()));
+                .collect(Collectors.toMap(s -> s.canonicalURI(), s -> s.uri(), (a, b) -> a));
 
         canonicalUriMap.putAll(canonical);
 

--- a/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/ExtensionBinding.java
+++ b/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/ExtensionBinding.java
@@ -51,6 +51,15 @@ public interface ExtensionBinding {
     public Collection<Extension> getExtensionsFor(WebResource resource);
 
     /**
+     * Determine which of the given extensions bind to the given resource.
+     *
+     * @param resource Candidate resource
+     * @param from Candidate extensions
+     * @return All extensions from the list that bind to the resource, or empty if none.
+     */
+    public Collection<Extension> getExtensionsFor(WebResource resource, Collection<Extension> from);
+
+    /**
      * Determine all known extensions that bind to the given resource, given its URI.
      * <p>
      * The given URI may be a resource in the repository, on the web, or otherwise within a registry specified by the
@@ -65,5 +74,14 @@ public interface ExtensionBinding {
      * @return All extensions that bind to the given resource, or an empty collection if none.
      */
     public Collection<Extension> getExtensionsFor(URI resourceURI);
+
+    /**
+     * Determine which of the given extensions bind to the given resource.
+     *
+     * @param resourceURI URI of resource, will be dereferenced.
+     * @param from from Candidate extensions
+     * @return All extensions from the list that bind to the resource, or empty if none.
+     */
+    public Collection<Extension> getExtensionsFor(URI resourceURI, Collection<Extension> from);
 
 }

--- a/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Routing.java
+++ b/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Routing.java
@@ -56,6 +56,22 @@ public interface Routing {
     public URI serviceDocFor(URI resource);
 
     /**
+     * Get the endpoint for the service doc of a given resource path.
+     *
+     * @param resourcePath repository resource path
+     * @return URI that resolves to the service document.
+     */
+    public URI serviceDocFor(String resourcePath);
+
+    /**
+     * Get the intercept (proxy) URI for a given resource.
+     *
+     * @param resource Fedora resource URI
+     * @return URI that routes through the intercept(proxy) endpoint.
+     */
+    public URI interceptUriFor(URI resource);
+
+    /**
      * Get the identifying path compoment for the given fedora resource URI.
      *
      * @param resourceURI the resource URI.

--- a/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Routing.java
+++ b/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Routing.java
@@ -35,11 +35,11 @@ public interface Routing {
     /** Repository or resource-scoped exposed service URI */
     public static final String HTTP_HEADER_EXPOSED_SERVICE_URI = "Apix-Exposed-Uri";
 
-    /** Reppsitory root (baseURI) */
+    /** Repository root (baseURI) */
     public static final String HTTP_HEADER_REPOSITORY_ROOT_URI = "Apix-Ldp-Root";
 
     /**
-     * Get the endpoint for the service exposed by the given extension on the given resource.
+     * /** Get the endpoint for the service exposed by the given extension on the given resource.
      *
      * @param spec specification for exposing a service
      * @param onResource the resource on which the service is exposed.

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/Util.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/Util.java
@@ -45,7 +45,7 @@ public abstract class Util {
      * @return Normalized segmen
      */
     public static String terminal(final String path) {
-        return path.replaceFirst("^/", "");
+        return path.equals("") ? "/" : path.replaceFirst("^/", "");
     }
 
     /**

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/Util.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/Util.java
@@ -20,6 +20,15 @@ package org.fcrepo.apix.routing;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+
+import org.fcrepo.apix.model.Extension;
+import org.fcrepo.apix.model.ServiceInstance;
+import org.fcrepo.apix.model.components.ResourceNotFoundException;
+import org.fcrepo.apix.model.components.ServiceInstanceRegistry;
+import org.fcrepo.apix.model.components.ServiceRegistry;
 
 /**
  * URI parsiing and manipulation utilities.
@@ -27,6 +36,8 @@ import java.util.Arrays;
  * @author apb@jhu.edu
  */
 public abstract class Util {
+
+    private static final Random random = new Random();
 
     /**
      * Normalize a URI path segment to remove forward and trailing slashes, if present.
@@ -59,5 +70,67 @@ public abstract class Util {
                 Arrays.stream(segments)
                         .reduce((a, b) -> String.join("/", segment(a.toString()), terminal(b.toString())))
                         .get().toString());
+    }
+
+    /**
+     * Find an instance of the consumed service for an exposing extension.
+     *
+     * @param extension The extension
+     * @param serviceRegistry A service registry.
+     * @return URI if a service instance endpoint.
+     */
+    public static URI exposedServiceInstance(final Extension extension, final ServiceRegistry serviceRegistry) {
+        final URI consumedServiceURI = exactlyOne(extension.exposed().consumed(),
+                "Exposed services must have exactly one consumed service in extension: " +
+                        extension.uri());
+
+        return instance(consumedServiceURI, serviceRegistry);
+    }
+
+    /**
+     * Find instance of the consumed service for an intercepting extension.
+     *
+     * @param extension The extension
+     * @param serviceRegistry The service registry
+     * @return URI of a service instance endpoint
+     */
+    public static URI interceptingServiceInstance(final Extension extension, final ServiceRegistry serviceRegistry) {
+        final URI consumedServiceURI = exactlyOne(extension.intercepted().consumed(),
+                "Exposed services must have exactly one consumed service in extension: " +
+                        extension.uri());
+        return instance(consumedServiceURI, serviceRegistry);
+
+    }
+
+    private static URI instance(final URI serviceURI, final ServiceRegistry serviceRegistry) {
+        final ServiceInstanceRegistry instanceRegistry = serviceRegistry.instancesOf(serviceRegistry.getService(
+                serviceURI));
+
+        if (instanceRegistry == null) {
+            throw new ResourceNotFoundException("No instance registry for service " + serviceURI);
+        }
+
+        final ServiceInstance instance = oneOf(instanceRegistry.instances(),
+                "There must be at least one service instance for " + serviceURI);
+
+        return oneOf(
+                instance.endpoints(),
+                "There must be at least one endpoint for instances of " + serviceURI);
+    }
+
+    private static <T> T exactlyOne(final Collection<T> of, final String errMsg) {
+        if (of.size() != 1) {
+            throw new ResourceNotFoundException(errMsg);
+        }
+
+        return of.iterator().next();
+    }
+
+    private static <T> T oneOf(final List<T> of, final String errMsg) {
+        if (of.isEmpty()) {
+            throw new ResourceNotFoundException(errMsg);
+        }
+
+        return of.get(random.nextInt(of.size()));
     }
 }

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
@@ -216,6 +216,7 @@ public class RoutingImpl extends RouteBuilder {
     });
 
     final Processor ADD_SERVICE_HEADER = (ex -> {
+
         ex.getIn().setHeader("Link",
                 String.format("<%s>; rel=\"service\"", routing.serviceDocFor(
                         ex.getIn().getHeader(Exchange.HTTP_PATH, String.class))));

--- a/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -37,6 +37,7 @@
     <property name="port" value="${apix.port}" />
     <property name="discoveryPath" value="${apix.discoveryPath}" />
     <property name="exposePath" value="${apix.exposePath}" />
+    <property name="interceptPath" value="${apix.interceptPath}" />
     <property name="fcrepoBaseURI" value="${fcrepo.baseURI}" />
   </bean>
 
@@ -52,6 +53,7 @@
     <property name="serviceDiscovery" ref="serviceDiscoveryImpl" />
     <property name="serviceRegistry" ref="serviceRegistry" />
     <property name="exposedServiceURIAnalyzer" ref="exposedServiceUriAnalyzer" />
+    <property name="routing" ref="routingStub" />
   </bean>
 
   <bean id="serviceDiscoveryImpl" class="org.fcrepo.apix.routing.impl.ServiceDocumentGenerator">

--- a/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -56,10 +56,17 @@
     <property name="routing" ref="routingStub" />
   </bean>
 
+  <bean id="interceptImpl" class="org.fcrepo.apix.routing.impl.GenericInterceptExecution">
+    <property name="fcrepoBaseURI" value="${fcrepo.baseURI}" />
+    <property name="extensionBinding" ref="extensionBinding" />
+    <property name="serviceRegistry" ref="serviceRegistry" />
+    <property name="extensionRegistry" ref="extensionRegistry" />
+  </bean>
+
   <bean id="serviceDiscoveryImpl" class="org.fcrepo.apix.routing.impl.ServiceDocumentGenerator">
     <property name="extensionBinding" ref="extensionBinding" />
-    <property name="routing" ref="routingStub" />
     <property name="relativeURIs" value="${discovery.relativeURIs}" />
+    <property name="routing" ref="routingStub" />
   </bean>
 
   <service id="routing" interface="org.fcrepo.apix.model.components.Routing"
@@ -71,7 +78,11 @@
   <service id="uriAnalyzerUpdate" interface="org.fcrepo.apix.model.components.Updateable"
     ref="exposedServiceUriAnalyzer" />
 
+  <service id="interceptUpdate" interface="org.fcrepo.apix.model.components.Updateable"
+    ref="interceptImpl" />
+
   <camel:camelContext>
     <camel:routeBuilder ref="routingImpl" />
+    <camel:routeBuilder ref="interceptImpl" />
   </camel:camelContext>
 </blueprint>

--- a/src/site/markdown/execution-and-routing.md
+++ b/src/site/markdown/execution-and-routing.md
@@ -138,10 +138,14 @@ Finally, the service responds with an image:
 
 This execution engine supports the intercepting modality.  It operates by proxying a request or response to a service instance, and inspecting the response.  Like the generic endpoint proxy, it adds a header `Apix-Ldp-Resource` to the request before sending it to the consumed service instance.
 
-* If the response is a 2xx code with no body, the extension will pass the request unmodified.   Headers will be merged.
-* If the response is a 2xx code with a body,   the body of the request will be substituted with the response body.  Headers will be merged.
-* If the response is a redirect, it will be followed.
-* If the response an error (4xx+), that response will immediately be returned to the client.
+* If the response  from a given service is a 2xx code with no body, the extension will pass the request unmodified.   Headers will be merged.
+* If the response from a given service is a 2xx code with a body,   the body of the request will be substituted with the response body.  Headers will be merged.
+* If the response from a given service is an error or redirect (3xx+), that response will immediately be returned to the client.
+
+Responses from the repository are also intercepted and passed to the extension under similar rules:
+
+* If the response from a given service is a 2xx, headers will be merged, and the body will be replaced, if present
+* If the response from a given service is an error or redirect, it is ignored.
 
 <h4><a id="intercepting-example" href="#intercepting-example" class="anchor">Intercepting Example</a></h4>
 


### PR DESCRIPTION
Implements intercepting requests/responses to repository via a proxy pattern, as described in #11 and in the design docs as [Generic Intercepting Proxy](https://github.com/fcrepo4-labs/fcrepo-api-x/blob/master/src/site/markdown/execution-and-routing.md#generic-intercepting-proxy)
