### PR TITLE
Create simple API-X updater/listener 

### DIFF
--- a/fcrepo-api-x-integration/pom.xml
+++ b/fcrepo-api-x-integration/pom.xml
@@ -33,6 +33,7 @@
             <pax.exam.karaf.version>${karaf.version}</pax.exam.karaf.version>
             <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
             <fcrepo.cxtPath>${fcrepo.cxtPath}</fcrepo.cxtPath>
+            <fcrepo.dynamic.jms.port>${fcrepo.dynamic.jms.port}</fcrepo.dynamic.jms.port>
             <project.basedir>${project.basedir}</project.basedir>
             <services.dynamic.test.port>${services.dynamic.test.port}</services.dynamic.test.port>
           </systemPropertyVariables>
@@ -62,6 +63,8 @@
             <portName>apix.dynamic.test.port</portName>
             <portName>fcrepo.dynamic.test.port</portName>
             <portName>services.dynamic.test.port</portName>
+            <portName>fcrepo.dynamic.jms.port</portName>
+            <portName>fcrepo.dynamic.stomp.port</portName>
           </portNames>
         </configuration>
         <executions>
@@ -87,6 +90,8 @@
             <systemProperties>
               <fcrepo.home>${project.build.directory}/fcrepo</fcrepo.home>
               <fcrepo.modeshape.configuration>classpath:/config/minimal-default/repository.json</fcrepo.modeshape.configuration>
+              <fcrepo.dynamic.jms.port>${fcrepo.dynamic.jms.port}</fcrepo.dynamic.jms.port>
+              <fcrepo.dynamic.stomp.port>${fcrepo.dynamic.stomp.port}</fcrepo.dynamic.stomp.port>
             </systemProperties>
           </container>
           <deployables>

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafIT.java
@@ -130,6 +130,8 @@ public interface KarafIT {
                     "fcrepo.dynamic.test.port")),
             editConfigurationFilePut("etc/system.properties", "services.dynamic.test.port", System.getProperty(
                     "services.dynamic.test.port")),
+            editConfigurationFilePut("etc/system.properties", "fcrepo.dynamic.jms.port", System.getProperty(
+                    "fcrepo.dynamic.jms.port")),
             editConfigurationFilePut("etc/system.properties", "project.basedir", System.getProperty(
                     "project.basedir")),
             editConfigurationFilePut("/etc/system.properties", "fcrepo.cxtPath", System.getProperty(
@@ -248,5 +250,4 @@ public interface KarafIT {
             }
         }
     }
-
 }

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafIT.java
@@ -144,7 +144,8 @@ public interface KarafIT {
 
             deployFile("cfg/org.fcrepo.apix.jena.cfg"),
             deployFile("cfg/org.fcrepo.apix.registry.http.cfg"),
-            deployFile("cfg/org.fcrepo.apix.routing.cfg")
+            deployFile("cfg/org.fcrepo.apix.routing.cfg"),
+            deployFile("cfg/org.fcrepo.apix.listener.cfg")
         };
 
         options.addAll(Arrays.asList(defaultOptions));

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ListenerUpdateIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ListenerUpdateIT.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.util.Hashtable;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.fcrepo.apix.model.components.Updateable;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Verifies that the listener updates updateable services.
+ *
+ * @author apb@jhu.edu
+ */
+@RunWith(PaxExam.class)
+public class ListenerUpdateIT implements KarafIT {
+
+    @Inject
+    public BundleContext cxt;
+
+    @Rule
+    public TestName name;
+
+    @Override
+    public String testClassName() {
+        return ListenerUpdateIT.class.getSimpleName();
+    }
+
+    @Override
+    public String testMethodName() {
+        return name.getMethodName();
+    }
+
+    @BeforeClass
+    public static void init() throws Exception {
+        KarafIT.createContainers();
+    }
+
+    // Verify that we can add an Updateable service,
+    // and that it updates itself when a new object is deposited into the repo
+    @Test
+    public void addUpdateableTest() throws Exception {
+
+        final BlockingQueue<URI> objects = new LinkedBlockingQueue<>();
+
+        System.out.println("Registering service");
+        cxt.registerService(Updateable.class, new Updateable() {
+
+            @Override
+            public void update(final URI uri) {
+                System.out.println("Handling!");
+                objects.add(uri);
+            }
+
+            @Override
+            public void update() {
+                fail("Should have called specific URI-based update");
+            }
+        }, new Hashtable<>());
+
+        final URI OBJECT = client.post(objectContainer).perform().getLocation();
+
+        URI uri;
+        while (!OBJECT.equals(uri = objects.poll(10, TimeUnit.SECONDS))) {
+            assertNotNull("Our object did not update", uri);
+        }
+
+        assertEquals(OBJECT, uri);
+    }
+
+}

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ListenerUpdateIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ListenerUpdateIT.java
@@ -76,12 +76,10 @@ public class ListenerUpdateIT implements KarafIT {
 
         final BlockingQueue<URI> objects = new LinkedBlockingQueue<>();
 
-        System.out.println("Registering service");
         cxt.registerService(Updateable.class, new Updateable() {
 
             @Override
             public void update(final URI uri) {
-                System.out.println("Handling!");
                 objects.add(uri);
             }
 

--- a/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.listener.cfg
+++ b/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.listener.cfg
@@ -1,1 +1,2 @@
 fcrepo.baseURI = http://localhost:${fcrepo.dynamic.test.port}/${fcrepo.cxtPath}/rest
+broker.uri = tcp://localhost:${fcrepo.dynamic.jms.port}

--- a/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.listener.cfg
+++ b/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.listener.cfg
@@ -1,0 +1,1 @@
+fcrepo.baseURI = http://localhost:${fcrepo.dynamic.test.port}/${fcrepo.cxtPath}/rest

--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/JenaServiceRegistry.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/JenaServiceRegistry.java
@@ -81,8 +81,10 @@ public class JenaServiceRegistry extends WrappingRegistry implements ServiceRegi
 
     @Override
     public void update(final URI uri) {
-        // TODO: Optimize
-        this.update();
+        if (hasInDomain(uri)) {
+            // TODO: This can be optimized more
+            update();
+        }
     }
 
     @Override
@@ -200,6 +202,11 @@ public class JenaServiceRegistry extends WrappingRegistry implements ServiceRegi
     // Try looking in canonical map first
     private URI resourceURI(final URI uri) {
         return Optional.ofNullable(canonicalUriMap.get(uri)).orElse(uri);
+    }
+
+    @Override
+    public boolean hasInDomain(final URI uri) {
+        return delegate.hasInDomain(uri) || canonicalUriMap.values().contains(uri);
     }
 
 }

--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/JenaServiceRegistry.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/JenaServiceRegistry.java
@@ -74,9 +74,7 @@ public class JenaServiceRegistry extends WrappingRegistry implements ServiceRegi
 
         canonicalUriMap.putAll(canonical);
 
-        canonicalUriMap.keySet().stream()
-                .filter(k -> !canonical.containsKey(k))
-                .forEach(canonicalUriMap::remove);
+        canonicalUriMap.keySet().removeIf(k -> !canonical.containsKey(k));
     }
 
     @Override

--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/LdpContainerRegistry.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/LdpContainerRegistry.java
@@ -280,4 +280,9 @@ public class LdpContainerRegistry implements Registry {
             throw new RuntimeException("Error retrieving container content from " + containerContent, e);
         }
     }
+
+    @Override
+    public boolean hasInDomain(final URI uri) {
+        return uri.toString().startsWith(containerId.toString());
+    }
 }

--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistry.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistry.java
@@ -180,4 +180,9 @@ public class LookupOntologyRegistry implements OntologyRegistry {
     public boolean contains(final URI id) {
         return ontologyIRIsToLocation.containsKey(id) || registry.contains(id);
     }
+
+    @Override
+    public boolean hasInDomain(final URI uri) {
+        return registry.hasInDomain(uri);
+    }
 }

--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistry.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistry.java
@@ -23,14 +23,18 @@ import static org.fcrepo.apix.jena.Util.parse;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BinaryOperator;
+import java.util.stream.Collectors;
 
 import org.fcrepo.apix.model.WebResource;
 import org.fcrepo.apix.model.components.OntologyRegistry;
 import org.fcrepo.apix.model.components.Registry;
+import org.fcrepo.apix.model.components.Updateable;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
@@ -48,23 +52,23 @@ import org.slf4j.LoggerFactory;
  * </p>
  * <p>
  * This indexes all ontologies upon initialization, and maintains the index in response to {@link #put(WebResource)}
- * or {@link #put(WebResource, URI)}. TODO: remove entries for {{@link #delete(URI)};
+ * or {@link #put(WebResource, URI)}.
  * </p>
  * <p>
- * For ontology registries backed by an LDP container in the repository, this class could be used by an asynchronous
+ * For ontology registries backed by an LDP container in the repository, this class may be used by an asynchronous
  * message consumer to update the ontology registry in response to ontologies added/removed manually by clients via
- * LDP interactions with the repository. TOOO: Create such a consumer.
+ * LDP interactions with the repository.
  * </p>
  *
  * @author apb@jhu.edu
  */
-public class LookupOntologyRegistry implements OntologyRegistry {
+public class LookupOntologyRegistry implements OntologyRegistry, Updateable {
 
     static final String RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 
     static final String OWL_ONTOLOGY = "http://www.w3.org/2002/07/owl#Ontology";
 
-    private Map<URI, URI> ontologyIRIsToLocation;
+    private final Map<URI, URI> ontologyIRIsToLocation = new ConcurrentHashMap<>();
 
     private Registry registry;
 
@@ -115,15 +119,15 @@ public class LookupOntologyRegistry implements OntologyRegistry {
     @Override
     public void delete(final URI uri) {
         registry.delete(uri);
+        update();
     }
 
     /** Try infinitely to read contents of registry in order to index ontologyIRIs */
     public void init() {
-        ontologyIRIsToLocation = new ConcurrentHashMap<>();
 
         for (boolean indexed = false; !indexed;) {
             try {
-                registry.list().stream().forEach(this::index);
+                update();
                 indexed = true;
             } catch (final Exception e) {
                 LOG.warn("Indexing existing ontologies failed, retrying: ", e);
@@ -131,7 +135,6 @@ public class LookupOntologyRegistry implements OntologyRegistry {
                     Thread.sleep(1000);
                 } catch (final InterruptedException i) {
                     Thread.currentThread().interrupt();
-                    ontologyIRIsToLocation = null;
                     return;
                 }
             }
@@ -151,7 +154,7 @@ public class LookupOntologyRegistry implements OntologyRegistry {
                         ontologyIRIsToLocation.get(ontologyIRI), ontologyLocation));
             }
 
-            LOG.debug("Registering ontology IRI {} which resolves to location {}", ontologyIRI, ontologyLocation);
+            LOG.debug("Indexing ontology IRI {} which resolves to location {}", ontologyIRI, ontologyLocation);
 
             ontologyIRIsToLocation.put(ontologyIRI, ontologyLocation);
         }
@@ -184,5 +187,32 @@ public class LookupOntologyRegistry implements OntologyRegistry {
     @Override
     public boolean hasInDomain(final URI uri) {
         return registry.hasInDomain(uri);
+    }
+
+    @Override
+    public void update() {
+        final Map<URI, URI> iriMap = registry.list().stream()
+                .flatMap(loc -> ontologyURIs(load(loc)).stream()
+                        .map(uri -> new SimpleEntry<URI, URI>(uri, loc)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, CONFLICT));
+
+        ontologyIRIsToLocation.putAll(iriMap);
+
+        ontologyIRIsToLocation.keySet().removeIf(iri -> !iriMap.containsKey(iri));
+
+        ontologyIRIsToLocation.entrySet().forEach(e -> LOG.debug(
+                "Indexing ontology IRI {} which resolves to location {}", e.getKey(), e.getValue()));
+    }
+
+    private static BinaryOperator<URI> CONFLICT = (v1, v2) -> {
+        throw new RuntimeException(
+                String.format("Resources %s and %s both define the same ontology IRI", v1, v2));
+    };
+
+    @Override
+    public void update(final URI inResponseTo) {
+        if (registry.hasInDomain(inResponseTo)) {
+            update();
+        }
     }
 }

--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/WrappingRegistry.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/WrappingRegistry.java
@@ -67,4 +67,9 @@ abstract class WrappingRegistry implements Registry {
         return delegate.contains(id);
     }
 
+    @Override
+    public boolean hasInDomain(final URI uri) {
+        return delegate.hasInDomain(uri);
+    }
+
 }

--- a/fcrepo-api-x-jena/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-jena/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -91,7 +91,10 @@
   <service id="jenaServiceRegistry" interface="org.fcrepo.apix.model.components.ServiceRegistry"
     ref="jenaServiceRegistryImpl" />
 
-  <service id="jenaServiceRegistryUpdater"
-    interface="org.fcrepo.apix.model.components.Updateable" ref="jenaServiceRegistryImpl" />
+  <service id="jenaServiceRegistryUpdater" interface="org.fcrepo.apix.model.components.Updateable"
+    ref="jenaServiceRegistryImpl" />
+
+  <service id="jenaOntologyRegistryUpdater" interface="org.fcrepo.apix.model.components.Updateable"
+    ref="jenaOntologyRegistryImpl" />
 
 </blueprint>

--- a/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LdpContainerRegistryTest.java
+++ b/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LdpContainerRegistryTest.java
@@ -20,6 +20,7 @@ package org.fcrepo.apix.jena.impl;
 
 import static org.fcrepo.apix.model.Ontologies.LDP_CONTAINS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.never;
@@ -204,5 +205,16 @@ public class LdpContainerRegistryTest {
 
         assertTrue(members.containsAll(expectedMembers));
         assertTrue(expectedMembers.containsAll(members));
+    }
+
+    @Test
+    public void domainTest() {
+        final LdpContainerRegistry toTest = new LdpContainerRegistry();
+        final String CONTAINER = "http://example.org/container";
+        toTest.setContainer(URI.create(CONTAINER));
+
+        assertTrue(toTest.hasInDomain(URI.create(CONTAINER)));
+        assertTrue(toTest.hasInDomain(URI.create(CONTAINER + "/other/path")));
+        assertFalse(toTest.hasInDomain(URI.create("http://bad.example.org/not")));
     }
 }

--- a/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistryTest.java
+++ b/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistryTest.java
@@ -90,16 +90,19 @@ public class LookupOntologyRegistryTest {
         final WebResource ontologyToPersist = new ReadableResource(this.getClass().getResourceAsStream(
                 "/ontologyWithoutIRI.ttl"), "text/turtle", ontologyLocationURI, null);
 
+        final ArrayList<URI> entries = new ArrayList<>();
+
         when(delegate.put(any(WebResource.class))).then(new Answer<URI>() {
 
             @Override
             public URI answer(final InvocationOnMock invocation) throws Throwable {
                 final WebResource submitted = ((WebResource) invocation.getArguments()[0]);
                 when(delegate.get(ontologyLocationURI)).thenReturn(submitted);
+                entries.add(ontologyLocationURI);
                 return ontologyLocationURI;
             }
         });
-        when(delegate.list()).thenReturn(new ArrayList<>());
+        when(delegate.list()).thenReturn(entries);
 
         toTest.setRegistryDelegate(delegate);
         toTest.init();

--- a/fcrepo-api-x-karaf/pom.xml
+++ b/fcrepo-api-x-karaf/pom.xml
@@ -48,6 +48,14 @@
 
     <dependency>
       <groupId>org.fcrepo.apix</groupId>
+      <artifactId>fcrepo-api-x-listener</artifactId>
+      <version>${project.version}</version>
+      <classifier>features</classifier>
+      <type>xml</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo.apix</groupId>
       <artifactId>fcrepo-api-x-model</artifactId>
       <version>${project.version}</version>
       <classifier>features</classifier>

--- a/fcrepo-api-x-karaf/src/main/feature/feature.xml
+++ b/fcrepo-api-x-karaf/src/main/feature/feature.xml
@@ -2,11 +2,13 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.3.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="fcrepo-api-x-karaf"
   xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
-  <repository>mvn:org.apache.camel.karaf/apache-camel/2.17.3/xml/features</repository>
+  <repository>mvn:org.apache.camel.karaf/apache-camel/${camel.version}/xml/features</repository>
+  <repository>mvn:org.apache.activemq/activemq-karaf/${activemq.version}/xml/features</repository>
   <feature name="fcrepo-api-x" description="All of api-x"
     version="${project.version}">
     <feature version="${project.version}">fcrepo-api-x-binding</feature>
     <feature version="${project.version}">fcrepo-api-x-jena</feature>
+    <feature version="${project.version}">fcrepo-api-x-listener</feature>
     <feature version="${project.version}">fcrepo-api-x-model</feature>
     <feature version="${project.version}">fcrepo-api-x-registry</feature>
     <feature version="${project.version}">fcrepo-api-x-routing</feature>

--- a/fcrepo-api-x-listener/pom.xml
+++ b/fcrepo-api-x-listener/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.fcrepo.apix</groupId>
+    <artifactId>fcrepo-api-x</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>fcrepo-api-x-listener</artifactId>
+  <packaging>bundle</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.fcrepo.apix</groupId>
+      <artifactId>fcrepo-api-x-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+      <version>${camel.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/fcrepo-api-x-listener/src/main/feature/feature.xml
+++ b/fcrepo-api-x-listener/src/main/feature/feature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.4.0"
+  name="fcrepo-api-x-listener">
+  <repository>mvn:org.apache.activemq/activemq-karaf/${activemq.version}/xml/features</repository>
+  <feature name="fcrepo-api-x-listener" description="fcrepo-api-x-listener">
+    version="${project.version}">
+    <feature version="${camel.version}">camel-jms</feature>
+    <feature version="${activemq.version}">activemq-camel</feature>
+  </feature>
+</features>

--- a/fcrepo-api-x-listener/src/main/java/org/fcrepo/apix/listener/impl/UpdateListener.java
+++ b/fcrepo-api-x-listener/src/main/java/org/fcrepo/apix/listener/impl/UpdateListener.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.listener.impl;
+
+import java.net.URI;
+import java.util.List;
+
+import org.fcrepo.apix.model.components.Updateable;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * @author apb@jhu.edu
+ */
+public class UpdateListener extends RouteBuilder {
+
+    private List<Updateable> toUpdate;
+
+    private String fcrepoBaseURI;
+
+    private static final String RESOURCE_PATH = "org.fcrepo.jms.identifier";
+
+    private static final String TYPE = "org.fcrepo.jms.resourceType";
+
+    private static final String TYPE_RESOURCE = "http://fedora.info/definitions/v4/repository#Resource";
+
+    /**
+     * Set the list of services to update
+     *
+     * @param list List of {@link Updateable} services to update.
+     */
+    public void setToUpdate(final List<Updateable> list) {
+        this.toUpdate = list;
+    }
+
+    /**
+     * Set the Fedora baseURI.
+     *
+     * @param uri Fedora baseURI.
+     */
+    public void setFcrepoBaseURI(final String uri) {
+        this.fcrepoBaseURI = uri.replaceFirst("/$", "");
+    }
+
+    @Override
+    public void configure() throws Exception {
+        from("{{input.uri}}").id("listener-update-apix")
+                .choice().when(e -> e.getIn().getHeader(TYPE, String.class).contains(TYPE_RESOURCE))
+                .process(e -> toUpdate.forEach(u -> u.update(objectURI(e))));
+    }
+
+    private URI objectURI(final Exchange e) {
+        return URI.create(fcrepoBaseURI + e.getIn().getHeader(RESOURCE_PATH));
+    }
+}

--- a/fcrepo-api-x-listener/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-listener/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+  xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+  xmlns:camel="http://camel.apache.org/schema/blueprint"
+  xsi:schemaLocation="
+       http://www.osgi.org/xmlns/blueprint/v1.0.0 https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+       http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0 http://aries.apache.org/schemas/blueprint-ext/blueprint-ext.xsd
+       http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0  http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+       http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+  <cm:property-placeholder persistent-id="org.fcrepo.apix.listener"
+    update-strategy="reload">
+    <cm:default-properties>
+      <cm:property name="input.uri" value="activemq:topic:fedora" />
+      <cm:property name="broker.uri" value="tcp://localhost:61616" />
+      <cm:property name="fcrepo.BaseURI" value="http://localhost:8080/fcrepo/rest" />
+    </cm:default-properties>
+  </cm:property-placeholder>
+
+  <reference-list id="toUpdate" member-type="service-object"
+    interface="org.fcrepo.apix.model.components.Updateable"
+    availability="optional" />
+
+  <bean id="activemq" class="org.apache.activemq.camel.component.ActiveMQComponent">
+    <property name="brokerURL" value="${broker.uri}" />
+  </bean>
+
+  <bean id="updaterRoutes" class="org.fcrepo.apix.listener.impl.UpdateListener">
+    <property name="toUpdate" ref="toUpdate" />
+    <property name="fcrepoBaseURI" value="${fcrepo.baseURI}" />
+  </bean>
+
+  <camel:camelContext id="apix-listener">
+    <camel:routeBuilder ref="updaterRoutes" />
+  </camel:camelContext>
+</blueprint>

--- a/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Registry.java
+++ b/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Registry.java
@@ -76,4 +76,16 @@ public interface Registry {
      */
     public boolean contains(URI id);
 
+    /**
+     * Determine if a URI is in the domain of this registry.
+     * <p>
+     * A resource is in a registry's domain if it is contained by the registry, or could potentially be contained by
+     * it, based on inspecting the URI (e.g. for the presence of a baseURI)
+     * </p>
+     *
+     * @param uri URI to test
+     * @return true if the URI is within the registry domain.
+     */
+    public boolean hasInDomain(URI uri);
+
 }

--- a/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/impl/HttpRegistry.java
+++ b/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/impl/HttpRegistry.java
@@ -238,4 +238,9 @@ public class HttpRegistry implements Registry {
     public void delete(final URI uri) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public boolean hasInDomain(final URI uri) {
+        return uri.getScheme().startsWith("http");
+    }
 }

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzer.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzer.java
@@ -88,9 +88,7 @@ public class ExposedServiceUriAnalyzer implements Updateable {
 
         endpoints.putAll(exts);
 
-        endpoints.keySet().stream()
-                .filter(k -> !exts.containsKey(k))
-                .forEach(endpoints::remove);
+        endpoints.keySet().removeIf(k -> !exts.containsKey(k));
     }
 
     @Override

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzer.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzer.java
@@ -95,8 +95,10 @@ public class ExposedServiceUriAnalyzer implements Updateable {
 
     @Override
     public void update(final URI inResponseTo) {
-        // TODO: optimize later
-        update();
+        if (extensions.hasInDomain(inResponseTo)) {
+            // TODO: This can be optimized more
+            update();
+        }
     }
 
     /**

--- a/fcrepo-api-x-routing/src/test/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzerTest.java
+++ b/fcrepo-api-x-routing/src/test/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzerTest.java
@@ -200,6 +200,7 @@ public class ExposedServiceUriAnalyzerTest {
     @Test
     public void updateURITest() {
         when(extensisons.getExtension(extension2URI)).thenReturn(extension2);
+        when(extensisons.hasInDomain(extension2URI)).thenReturn(true);
         when(extension2.isExposing()).thenReturn(true);
         when(extension2.exposed()).thenReturn(extension2Spec);
         when(extension2Spec.exposedAt()).thenReturn(extension2ExposedAt);

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <camel.version>2.17.3</camel.version>
+    <activemq.version>5.14.1</activemq.version>
+    <camel.version>2.18.0</camel.version>
     <cargo.version>1.5.0</cargo.version>
     <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
     <commons-io.version>2.5</commons-io.version>
@@ -287,6 +288,7 @@
     <module>fcrepo-api-x-karaf</module>
     <module>fcrepo-api-x-ontology</module>
     <module>fcrepo-api-x-test</module>
+    <module>fcrepo-api-x-listener</module>
   </modules>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <activemq.version>5.14.1</activemq.version>
-    <camel.version>2.18.0</camel.version>
+    <camel.version>2.17.3</camel.version>
     <cargo.version>1.5.0</cargo.version>
     <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
     <commons-io.version>2.5</commons-io.version>


### PR DESCRIPTION
Addresses #47 

This PR deploys a camel context with a route that updates all `Updateable` services in response to messages on Fedora resources.  In addition:
- The ontology registry has been made `Updateable` to listen for new ontologies in extensions
- Existing `Updateable` services have been optimized  only to respond to `update(uri)` if the URI is relevant to their domain
