### PR TITLE
Separate build profiles for osgi/non-osgi environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: true
 # 'install' necessary to generate artifacts used by pax exam 
 # - this is the default value assigned by Travis, but included for clarity
-install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+install: mvn install -Posgi -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script:
   - sudo service mysql stop
   - sudo service postgresql stop
@@ -16,6 +16,7 @@ script:
   - sudo service sshguard stop
   - sudo service ssh stop
   - mvn verify
+  - mvn verify -Posgi
 jdk:
 - oraclejdk8
 after_failure:

--- a/fcrepo-api-x-binding/pom.xml
+++ b/fcrepo-api-x-binding/pom.xml
@@ -17,25 +17,54 @@
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.karaf.tooling</groupId>
-        <artifactId>karaf-maven-plugin</artifactId>
-      </plugin>
-
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>osgi</id>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.karaf.tooling</groupId>
+            <artifactId>karaf-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <scope>provided</scope>
+        </dependency>
+
+      </dependencies>
+    </profile>
+  </profiles>
 
   <dependencies>
     <dependency>
       <groupId>org.fcrepo.apix</groupId>
       <artifactId>fcrepo-api-x-model</artifactId>
       <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/fcrepo-api-x-integration/pom.xml
+++ b/fcrepo-api-x-integration/pom.xml
@@ -12,6 +12,88 @@
     <fcrepo.cxtPath>fcrepo</fcrepo.cxtPath>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <properties>
+        <fcrepo.dynamic.test.port>8080</fcrepo.dynamic.test.port>
+        <fcrepo.dynamic.jms.port>61616</fcrepo.dynamic.jms.port>
+        <fcrepo.dynamic.stomp.port>61613</fcrepo.dynamic.stomp.port>
+      </properties>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <!-- This is intentional, due to a bug in 2.19.x -->
+            <version>2.18.1</version>
+            <configuration>
+              <excludes>
+                <exclude>**/Karaf*</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>osgi</id>
+
+      <build>
+        <plugins>
+
+          <plugin>
+            <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-maven2-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-container</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop-container</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.fcrepo.apix</groupId>
+          <artifactId>fcrepo-api-x-karaf</artifactId>
+          <version>${project.version}</version>
+          <classifier>features</classifier>
+          <type>xml</type>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.camel.karaf</groupId>
+          <artifactId>apache-camel</artifactId>
+          <version>${camel.version}</version>
+          <classifier>features</classifier>
+          <type>xml</type>
+          <scope>test</scope>
+        </dependency>
+
+      </dependencies>
+    </profile>
+
+  </profiles>
+
   <build>
     <plugins>
       <plugin>
@@ -110,22 +192,6 @@
             </properties>
           </configuration>
         </configuration>
-        <executions>
-          <execution>
-            <id>start-container</id>
-            <phase>pre-integration-test</phase>
-            <goals>
-              <goal>start</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>stop-container</id>
-            <phase>post-integration-test</phase>
-            <goals>
-              <goal>stop</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
     </plugins>
@@ -140,29 +206,6 @@
   </build>
 
   <dependencies>
-
-    <dependency>
-      <groupId>org.fcrepo.apix</groupId>
-      <artifactId>fcrepo-api-x-karaf</artifactId>
-      <version>${project.version}</version>
-      <classifier>features</classifier>
-      <type>xml</type>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.camel.karaf</groupId>
-      <artifactId>apache-camel</artifactId>
-      <version>${camel.version}</version>
-      <classifier>features</classifier>
-      <type>xml</type>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.fcrepo.apix</groupId>

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafExposedServiceIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafExposedServiceIT.java
@@ -72,7 +72,7 @@ import org.osgi.framework.BundleContext;
  * @author apb@jhu.edu
  */
 @RunWith(PaxExam.class)
-public class ExposedServiceIT implements KarafIT {
+public class KarafExposedServiceIT implements KarafIT {
 
     final String serviceEndpoint = "http://127.0.0.1:" + System.getProperty("services.dynamic.test.port") +
             "/ExposedServiceIT";
@@ -101,7 +101,7 @@ public class ExposedServiceIT implements KarafIT {
 
     @Override
     public String testClassName() {
-        return ExposedServiceIT.class.getSimpleName();
+        return KarafExposedServiceIT.class.getSimpleName();
     }
 
     @Rule

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafInterceptingModalityIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafInterceptingModalityIT.java
@@ -47,7 +47,7 @@ import org.ops4j.pax.exam.junit.PaxExam;
  * @author apb@jhu.edu
  */
 @RunWith(PaxExam.class)
-public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT {
+public class KarafInterceptingModalityIT extends ServiceBasedTest implements KarafIT {
 
     final String TEST_OBJECT_TYPE = "test:InterceptingModalityIT#object";
 
@@ -59,7 +59,7 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
 
     @Override
     public String testClassName() {
-        return InterceptingModalityIT.class.getSimpleName();
+        return KarafInterceptingModalityIT.class.getSimpleName();
     }
 
     @Override

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafListenerUpdateIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafListenerUpdateIT.java
@@ -46,7 +46,7 @@ import org.osgi.framework.BundleContext;
  * @author apb@jhu.edu
  */
 @RunWith(PaxExam.class)
-public class ListenerUpdateIT implements KarafIT {
+public class KarafListenerUpdateIT implements KarafIT {
 
     @Inject
     public BundleContext cxt;
@@ -56,7 +56,7 @@ public class ListenerUpdateIT implements KarafIT {
 
     @Override
     public String testClassName() {
-        return ListenerUpdateIT.class.getSimpleName();
+        return KarafListenerUpdateIT.class.getSimpleName();
     }
 
     @Override

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafRepositoryExtensionBindingIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafRepositoryExtensionBindingIT.java
@@ -54,7 +54,7 @@ import org.osgi.framework.BundleContext;
  * @author apb@jhu.edu
  */
 @RunWith(PaxExam.class)
-public class RepositoryExtensionBindingIT implements KarafIT {
+public class KarafRepositoryExtensionBindingIT implements KarafIT {
 
     private static final URI ORE_ONTOLOGY_IRI = URI.create("http://www.openarchives.org/ore/terms/");
 

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafServiceDocumentIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafServiceDocumentIT.java
@@ -49,7 +49,7 @@ import org.ops4j.pax.exam.util.Filter;
  * @author apb@jhu.edu
  */
 @RunWith(PaxExam.class)
-public class ServiceDocumentIT implements KarafIT {
+public class KarafServiceDocumentIT implements KarafIT {
 
     @Inject
     public ServiceDiscovery discovery;
@@ -69,7 +69,7 @@ public class ServiceDocumentIT implements KarafIT {
 
     @Override
     public String testClassName() {
-        return ServiceDocumentIT.class.getSimpleName();
+        return KarafServiceDocumentIT.class.getSimpleName();
     }
 
     @Override

--- a/fcrepo-api-x-jena/pom.xml
+++ b/fcrepo-api-x-jena/pom.xml
@@ -17,15 +17,95 @@
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.karaf.tooling</groupId>
-        <artifactId>karaf-maven-plugin</artifactId>
-      </plugin>
-
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.jena</groupId>
+          <artifactId>jena-arq</artifactId>
+        </dependency>
+
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>osgi</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.karaf.tooling</groupId>
+            <artifactId>karaf-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+     
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.jena</groupId>
+          <artifactId>jena-osgi</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>com.github.andrewoma.dexx</groupId>
+          <artifactId>collection</artifactId>
+          <version>0.6</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.servicemix.bundles</groupId>
+          <artifactId>org.apache.servicemix.bundles.xmlresolver</artifactId>
+          <version>1.2_5</version>
+        </dependency>
+        
+        <dependency>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+          <version>1.4.01</version>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.servicemix.bundles</groupId>
+          <artifactId>org.apache.servicemix.bundles.xerces</artifactId>
+          <version>2.11.0_1</version>
+          <exclusions>
+            <exclusion>
+              <groupId>xml-apis</groupId>
+              <artifactId>xml-apis</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <dependencies>
+
     <dependency>
       <groupId>org.fcrepo.apix</groupId>
       <artifactId>fcrepo-api-x-model</artifactId>
@@ -45,50 +125,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-osgi</artifactId>
-    </dependency>
-
-    <!-- For OSGi -->
-    <dependency>
-      <groupId>com.github.andrewoma.dexx</groupId>
-      <artifactId>collection</artifactId>
-      <version>0.6</version>
-    </dependency>
-
-    <!-- For OSGi -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-    </dependency>
-
-    <!-- for OSGi -->
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.xmlresolver</artifactId>
-      <version>1.2_5</version>
-    </dependency>
-
-    <!-- for OSGi -->
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.xerces</artifactId>
-      <version>2.11.0_1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -97,13 +133,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-core</artifactId>
-      <version>${jena.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/fcrepo-api-x-listener/pom.xml
+++ b/fcrepo-api-x-listener/pom.xml
@@ -11,17 +11,67 @@
 
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.karaf.tooling</groupId>
-        <artifactId>karaf-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.camel</groupId>
+          <artifactId>camel-core</artifactId>
+          <version>${camel.version}</version>
+        </dependency>
+
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>osgi</id>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.karaf.tooling</groupId>
+            <artifactId>karaf-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.camel</groupId>
+          <artifactId>camel-core</artifactId>
+          <version>${camel.version}</version>
+          <scope>provided</scope>
+        </dependency>
+
+      </dependencies>
+    </profile>
+  </profiles>
 
   <dependencies>
 
@@ -29,13 +79,6 @@
       <groupId>org.fcrepo.apix</groupId>
       <artifactId>fcrepo-api-x-model</artifactId>
       <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-core</artifactId>
-      <version>${camel.version}</version>
-      <scope>provided</scope>
     </dependency>
 
   </dependencies>

--- a/fcrepo-api-x-registry/pom.xml
+++ b/fcrepo-api-x-registry/pom.xml
@@ -9,16 +9,72 @@
   <artifactId>fcrepo-api-x-registry</artifactId>
   <packaging>bundle</packaging>
 
+  <profiles>
+
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </dependency>
+
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>osgi</id>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.karaf.tooling</groupId>
+            <artifactId>karaf-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore-osgi</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient-osgi</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.karaf.tooling</groupId>
-        <artifactId>karaf-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
@@ -38,30 +94,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore-osgi</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-    </dependency>
-
-    <!-- TODO: Try using fcrepo-java-client <dependency> <groupId>org.fcrepo.client</groupId> 
-      <artifactId>fcrepo-java-client</artifactId> <version>0.2.0</version> <exclusions> 
-      <exclusion> <groupId>org.apache.httpcomponents</groupId> <artifactId>httpclient</artifactId> 
-      </exclusion> <exclusion> <groupId>org.apache.httpcomponents</groupId> <artifactId>httpcore</artifactId> 
-      </exclusion> </exclusions> </dependency> -->
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/fcrepo-api-x-routing/pom.xml
+++ b/fcrepo-api-x-routing/pom.xml
@@ -8,20 +8,89 @@
   </parent>
   <artifactId>fcrepo-api-x-routing</artifactId>
   <packaging>bundle</packaging>
-
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.karaf.tooling</groupId>
-        <artifactId>karaf-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.camel</groupId>
+          <artifactId>camel-core</artifactId>
+          <version>${camel.version}</version>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.camel</groupId>
+          <artifactId>camel-jetty</artifactId>
+          <version>${camel.version}</version>
+        </dependency>
+
+      </dependencies>
+    </profile>
+
+    <profile>
+      <id>osgi</id>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.karaf.tooling</groupId>
+            <artifactId>karaf-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+          <version>1.4.01</version>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.camel</groupId>
+          <artifactId>camel-core</artifactId>
+          <version>${camel.version}</version>
+          <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>org.apache.camel</groupId>
+          <artifactId>camel-jetty</artifactId>
+          <version>${camel.version}</version>
+          <scope>provided</scope>
+        </dependency>
+
+      </dependencies>
+    </profile>
+  </profiles>
 
   <dependencies>
     <dependency>
@@ -37,36 +106,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-core</artifactId>
-      <version>${camel.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.camel</groupId>
-      <artifactId>camel-jetty</artifactId>
-      <version>${camel.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>provided</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-core</artifactId>
-      <version>${jena.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -80,5 +122,12 @@
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
   </properties>
 
   <build>
+
     <pluginManagement>
       <plugins>
         <plugin>
@@ -164,7 +165,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
-      
+
     </plugins>
 
 
@@ -177,6 +178,18 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons-io.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-arq</artifactId>
+        <version>${jena.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-core</artifactId>
+        <version>${jena.version}</version>
       </dependency>
 
       <dependency>
@@ -244,6 +257,18 @@
       </dependency>
 
       <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${httpcore.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${httpclient.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.osgi</groupId>
         <artifactId>org.osgi.service.component.annotations</artifactId>
         <version>${osgi.scr.version}</version>
@@ -277,6 +302,7 @@
 
     </dependencies>
   </dependencyManagement>
+
   <modules>
     <module>fcrepo-api-x-registry</module>
     <module>fcrepo-api-x-model</module>
@@ -284,8 +310,6 @@
     <module>fcrepo-api-x-binding</module>
     <module>fcrepo-api-x-execution</module>
     <module>fcrepo-api-x-jena</module>
-    <module>fcrepo-api-x-integration</module>
-    <module>fcrepo-api-x-karaf</module>
     <module>fcrepo-api-x-ontology</module>
     <module>fcrepo-api-x-test</module>
     <module>fcrepo-api-x-listener</module>
@@ -313,6 +337,13 @@
   </repositories>
 
   <profiles>
+    <profile>
+      <id>osgi</id>
+      <modules>
+        <module>fcrepo-api-x-integration</module>
+        <module>fcrepo-api-x-karaf</module>
+      </modules>
+    </profile>
     <profile>
       <id>POC</id>
       <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,7 @@
     <module>fcrepo-api-x-ontology</module>
     <module>fcrepo-api-x-test</module>
     <module>fcrepo-api-x-listener</module>
+    <module>fcrepo-api-x-integration</module>
   </modules>
 
   <licenses>
@@ -340,7 +341,6 @@
     <profile>
       <id>osgi</id>
       <modules>
-        <module>fcrepo-api-x-integration</module>
         <module>fcrepo-api-x-karaf</module>
       </modules>
     </profile>


### PR DESCRIPTION
This deals with the divergent dependency trees needed by osgi and non-osgi environments

The default profile performs a build solely based on the Maven reactor dependency tree, using "standard" dependencies (like jena-core).  The resulting build artifacts are still maven bundles

The `-Posgi` profile overrides the default profile, and uses a dependency tree that works in Karaf.  Dependencies that provide build fat jars for osgi (like `jena-osgi` to replace `jena-core`, `jena-arq`, etc) will have the osgi counterparts included in this dependency tree, with any redundant dependencies excluded.   This profile also builds Karaf feature files, and runs Karaf-based integration tests.
