### PR TITLE
Service document indexer routes

### DIFF
--- a/fcrepo-api-x-indexing/pom.xml
+++ b/fcrepo-api-x-indexing/pom.xml
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.fcrepo.apix</groupId>
+    <artifactId>fcrepo-api-x</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>fcrepo-api-x-indexing</artifactId>
+</project>

--- a/fcrepo-api-x-indexing/pom.xml
+++ b/fcrepo-api-x-indexing/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.fcrepo.apix</groupId>
@@ -6,4 +7,54 @@
     <version>0.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-api-x-indexing</artifactId>
+  <packaging>bundle</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.fcrepo.apix</groupId>
+      <artifactId>fcrepo-api-x-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo.camel</groupId>
+      <artifactId>fcrepo-camel</artifactId>
+      <version>${fcrepo-camel.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-osgi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+      <version>${camel.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+  </dependencies>
 </project>

--- a/fcrepo-api-x-indexing/src/main/feature/feature.xml
+++ b/fcrepo-api-x-indexing/src/main/feature/feature.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.4.0"
+  name="fcrepo-api-x-indexing">
+  <repository>mvn:org.apache.activemq/activemq-karaf/${activemq.version}/xml/features</repository>
+  <repository>mvn:org.fcrepo.camel/fcrepo-camel/${fcrepo-camel.version}/xml/features</repository>
+  <repository>mvn:org.fcrepo.camel/toolbox-features/${fcrepo-toolbox.version}/xml/features</repository>
+  <feature name="fcrepo-api-x-indexing" description="fcrepo-api-x-indexing">
+    version="${project.version}">
+    <feature version="${camel.version}">camel-core</feature>
+    <feature version="${camel.version}">camel-jetty</feature>
+    <feature version="${fcrepo-camel.version}">fcrepo-camel</feature>
+    <feature version="${fcrepo-toolbox.version}">fcrepo-service-activemq</feature>
+  </feature>
+</features>

--- a/fcrepo-api-x-indexing/src/main/java/org/fcrepo/apix/indexing/impl/ServiceIndexingRoutes.java
+++ b/fcrepo-api-x-indexing/src/main/java/org/fcrepo/apix/indexing/impl/ServiceIndexingRoutes.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.indexing.impl;
+
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_NAMED_GRAPH;
+import static org.fcrepo.camel.JmsHeaders.EVENT_TYPE;
+import static org.fcrepo.camel.JmsHeaders.IDENTIFIER;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.fcrepo.client.FcrepoLink;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;;
+
+/**
+ * @author apb@jhu.edu
+ */
+public class ServiceIndexingRoutes extends RouteBuilder {
+
+    static final String ROUTE_TRIGGER_REINDEX = "direct:reindex.trigger";
+
+    static final String ROUTE_INDEX_SERVICE_DOC = "direct:index.services";
+
+    static final String ROUTE_PERFORM_INDEX = "direct:index.services.perform";
+
+    static final String ROUTE_DELETE_SERVICE_DOC = "direct:delete.services";
+
+    static final String HEADER_SERVICE_DOC = "CamelApixServiceDocument";
+
+    private static final String RESOURCE_DELETION = "http://fedora.info/definitions/v4/event#ResourceDeletion";
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceIndexingRoutes.class);
+
+    private String extensionContainer;
+
+    private String reindexStream;
+
+    /**
+     * set the extension container path.
+     *
+     * @param path
+     */
+    public void setExtensionContainer(final String path) {
+        this.extensionContainer = path;
+    }
+
+    /**
+     * Set the reindex stream.
+     *
+     * @param stream
+     */
+    public void setReindexStream(final String stream) {
+        this.reindexStream = stream;
+    }
+
+    @Override
+    public void configure() throws Exception {
+
+        System.out.println("CONFIGURING");
+
+        from("{{service.index.stream}}")
+                .routeId("index-services")
+
+                .process(e -> System.out.println("INDEX"))
+
+                .choice()
+                .when(e -> e.getIn().getHeader(IDENTIFIER, String.class).startsWith(extensionContainer))
+                .to(ROUTE_TRIGGER_REINDEX)
+                .end()
+
+                .choice()
+                .when(header(EVENT_TYPE).isEqualTo(RESOURCE_DELETION))
+                .to(ROUTE_DELETE_SERVICE_DOC)
+                .otherwise()
+                .to(ROUTE_INDEX_SERVICE_DOC);
+
+        from("{{service.reindex.stream}}")
+                .routeId("reindex-services")
+                .to(ROUTE_INDEX_SERVICE_DOC);
+
+        from(ROUTE_INDEX_SERVICE_DOC)
+                .routeId("index-service-doc")
+
+                .setHeader(Exchange.HTTP_METHOD, constant("HEAD"))
+                .setHeader(Exchange.HTTP_PATH, header(IDENTIFIER))
+                .setHeader("Accept", constant("application/n-triples"))
+                .to("jetty:{{apix.baseUrl}}")
+                .process(GET_SERVICE_DOC_HEADER)
+                .split(header(HEADER_SERVICE_DOC)).to(ROUTE_PERFORM_INDEX);
+
+        from(ROUTE_PERFORM_INDEX).routeId("perform-index")
+                .removeHeaders("CamelHttp*")
+                .setHeader(Exchange.HTTP_URI, bodyAs(URI.class))
+                .setBody(constant(null))
+                .process(e -> System.out.println("MAKING REQUEST TO " + e.getIn().getHeader(Exchange.HTTP_URI)))
+                .to("jetty:http://localhost")
+                .removeHeaders("CamelHttp*")
+                .setHeader(FCREPO_NAMED_GRAPH, simple("{{triplestore.namedGraph}}"))
+                .process(new SparqlUpdateProcessor())
+                .log(LoggingLevel.INFO, LOG,
+                        "Indexing Serviced for Object ${headers[CamelFcrepoIdentifier]} " +
+                                "${headers[org.fcrepo.jms.identifier]}")
+                .to("jetty:{{triplestore.baseUrl}}");
+
+        from(ROUTE_TRIGGER_REINDEX).id("trigger-reindex")
+                .log(LoggingLevel.INFO, LOG,
+                        "Triggering reindex due update to extension ${headers[org.fcrepo.jms.identifier]}")
+                .setBody(constant("CamelFcrepoReindexingRecipients=" + reindexStream))
+                .setHeader(Exchange.HTTP_METHOD, constant("POST"))
+                .to("jetty:{{reindixing.service.uri}}");
+    }
+
+    @SuppressWarnings("unchecked")
+    final Processor GET_SERVICE_DOC_HEADER = ex -> {
+
+        final Set<String> rawLinkHeaders = new HashSet<>();
+
+        final Object linkHeader = ex.getIn().getHeader("Link");
+
+        if (linkHeader instanceof Collection) {
+            rawLinkHeaders.addAll((Collection<String>) linkHeader);
+        } else if (linkHeader instanceof String) {
+            rawLinkHeaders.add((String) linkHeader);
+        }
+
+        final List<URI> services = rawLinkHeaders.stream()
+                .map(FcrepoLink::new)
+                .filter(l -> l.getRel().equals("service"))
+                .map(l -> l.getUri()).collect(Collectors.toList());
+
+        ex.getIn().setHeader(HEADER_SERVICE_DOC, services);
+    };
+
+}

--- a/fcrepo-api-x-indexing/src/main/java/org/fcrepo/apix/indexing/impl/SparqlUpdateProcessor.java
+++ b/fcrepo-api-x-indexing/src/main/java/org/fcrepo/apix/indexing/impl/SparqlUpdateProcessor.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.indexing.impl;
+
+import static java.net.URLEncoder.encode;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.camel.processor.ProcessorUtils.langFromMimeType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.fcrepo.camel.FcrepoHeaders;
+import org.fcrepo.camel.processor.ProcessorUtils;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.jena.rdf.model.Model;
+
+/**
+ * Represents a processor for creating the sparql-update message to be passed to an external triplestore.
+ *
+ * @author Aaron Coburn
+ * @since Nov 8, 2014
+ */
+public class SparqlUpdateProcessor implements Processor {
+
+    /**
+     * Define how the message is processed.
+     *
+     * @param exchange the current camel message exchange
+     */
+    @Override
+    public void process(final Exchange exchange) throws IOException {
+
+        final Message in = exchange.getIn();
+
+        final ByteArrayOutputStream serializedGraph = new ByteArrayOutputStream();
+        final String subject = ProcessorUtils.getSubjectUri(in);
+        final String namedGraph = in.getHeader(FcrepoHeaders.FCREPO_NAMED_GRAPH, String.class);
+        final Model model = createDefaultModel().read(in.getBody(InputStream.class), subject,
+                langFromMimeType(in.getHeader(Exchange.CONTENT_TYPE, String.class)));
+
+        model.write(serializedGraph, "N-TRIPLE");
+
+        final StringBuilder query = new StringBuilder();
+        query.append(ProcessorUtils.deleteWhere(subject, namedGraph));
+        query.append(";\n");
+        query.append(ProcessorUtils.insertData(serializedGraph.toString("UTF-8"), namedGraph));
+
+        in.setBody("update=" + encode(query.toString(), "UTF-8"));
+        in.setHeader(Exchange.HTTP_METHOD, "POST");
+        in.setHeader(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded; charset=utf-8");
+    }
+}

--- a/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,14 +24,14 @@
       <cm:property name="reindixing.service.uri" value="http://localhost:9090/reindexing" />
       <cm:property name="ldp.path.extension.container"
         value="/extensions" />
-      <cm:property name="triplestore.namedGraph" value="service.reindex.stream" />
+      <cm:property name="triplestore.namedGraph" value="" />
     </cm:default-properties>
 
   </cm:property-placeholder>
 
   <bean id="indexerRoutes" class="org.fcrepo.apix.indexing.impl.ServiceIndexingRoutes">
     <property name="extensionContainer" value="${ldp.path.extension.container}" />
-    <property name="reindexStream" value="${}" />
+    <property name="reindexStream" value="${service.reindex.stream}" />
   </bean>
 
   <reference id="broker" interface="org.apache.camel.Component"

--- a/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+  xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0"
+  xmlns:camel="http://camel.apache.org/schema/blueprint"
+  xsi:schemaLocation="
+       http://www.osgi.org/xmlns/blueprint/v1.0.0 https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+       http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0 http://aries.apache.org/schemas/blueprint-ext/blueprint-ext.xsd
+       http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0  http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+       http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+
+  <cm:property-placeholder id="properties"
+    persistent-id="org.fcrepo.apix.indexing"
+    update-strategy="reload">
+
+    <cm:default-properties>
+      <cm:property name="error.maxRedeliveries" value="10" />
+      <cm:property name="apix.baseUrl" value="http://localhost:8080/fcrepo/rest" />
+      <cm:property name="service.index.stream" value="broker:topic:fedora" />
+      <cm:property name="service.reindex.stream" value="broker:queue:service.reindex" />
+      <cm:property name="triplestore.baseUrl"
+        value="http://localhost:8080/fuseki/test/update" />
+      <cm:property name="reindixing.service.uri" value="http://localhost:9090/reindexing" />
+      <cm:property name="ldp.path.extension.container"
+        value="/extensions" />
+      <cm:property name="triplestore.namedGraph" value="service.reindex.stream" />
+    </cm:default-properties>
+
+  </cm:property-placeholder>
+
+  <bean id="indexerRoutes" class="org.fcrepo.apix.indexing.impl.ServiceIndexingRoutes">
+    <property name="extensionContainer" value="${ldp.path.extension.container}" />
+    <property name="reindexStream" value="${}" />
+  </bean>
+
+  <reference id="broker" interface="org.apache.camel.Component"
+    filter="(osgi.jndi.service.name=fcrepo/Broker)" />
+
+  <camelContext id="FcrepoTriplestoreIndexer"
+    xmlns="http://camel.apache.org/schema/blueprint">
+    <routeBuilder ref="indexerRoutes" />
+  </camelContext>
+
+
+
+</blueprint>

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafIT.java
@@ -183,7 +183,7 @@ public interface KarafIT {
 
     public default Option deployFile(String path) {
         try {
-            return replaceConfigurationFile("deploy/" + new File(path).getName(),
+            return replaceConfigurationFile("etc/" + new File(path).getName(),
                     new File("target/test-classes", path));
         } catch (final Exception e) {
             throw new RuntimeException(e);

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafServiceIndexingIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafServiceIndexingIT.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.integration;
+
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.fcrepo.apix.model.components.Routing;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+
+/**
+ * @author apb@jhu.edu
+ */
+@RunWith(PaxExam.class)
+public class KarafServiceIndexingIT extends ServiceBasedTest {
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Inject
+    public Routing routing;
+
+    @Override
+    public String testClassName() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public String testMethodName() {
+        return name.getMethodName();
+    }
+
+    @BeforeClass
+    public static void init() throws Exception {
+        KarafIT.createContainers();
+    }
+
+    @Override
+    public List<Option> additionalKarafConfig() {
+        final MavenUrlReference apixRepo =
+                maven().groupId("org.fcrepo.apix")
+                        .artifactId("fcrepo-api-x-karaf").versionAsInProject()
+                        .classifier("features").type("xml");
+
+        return Arrays.asList(
+                deployFile("cfg/org.fcrepo.camel.service.activemq.cfg"),
+                deployFile("cfg/org.fcrepo.apix.indexing.cfg"),
+                features(apixRepo, "fcrepo-api-x-indexing"));
+    }
+
+    @Test
+    public void smokeTest() throws Exception {
+        onServiceRequest(ex -> {
+            System.out.println("\n<===");
+            ex.getIn().getHeaders().entrySet().forEach(System.out::println);
+            System.out.println("====>");
+        });
+
+        final URI OBJECT = client.post(routing.interceptUriFor(objectContainer)).perform().getLocation();
+
+        System.out.println("Object is " + OBJECT);
+
+        Thread.sleep(5000);
+
+    }
+
+}

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceBasedTest.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceBasedTest.java
@@ -82,7 +82,6 @@ public abstract class ServiceBasedTest implements KarafIT {
                 .artifactId("fcrepo-api-x-test")
                 .versionAsInProject();
         return Arrays.asList(mavenBundle(testBundle));
-        // return Arrays.asList(features(camelRepo, "camel-test"));
     }
 
     @Before

--- a/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.indexing.cfg
+++ b/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.indexing.cfg
@@ -1,0 +1,4 @@
+apix.baseUrl = http://localhost:${apix.dynamic.test.port}/fcrepo/rest
+triplestore.baseUrl = http://localhost:${services.dynamic.test.port}/TestService/fuseki
+reindixing.service.uri = http://localhost:${services.dynamic.test.port}/TestService/reindexing
+ldp.path.extension.container = /KarafServiceIndexingIT/extensions

--- a/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.camel.service.activemq.cfg
+++ b/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.camel.service.activemq.cfg
@@ -1,0 +1,1 @@
+jms.brokerUrl=tcp://localhost:${fcrepo.dynamic.jms.port}

--- a/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.camel.service.cfg
+++ b/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.camel.service.cfg
@@ -1,0 +1,1 @@
+fcrepo.baseUrl = http://localhost:${fcrepo.dynamic.test.port}/${fcrepo.cxtPath}/rest

--- a/fcrepo-api-x-karaf/pom.xml
+++ b/fcrepo-api-x-karaf/pom.xml
@@ -94,5 +94,13 @@
       <type>xml</type>
     </dependency>
 
+    <dependency>
+      <groupId>org.fcrepo.apix</groupId>
+      <artifactId>fcrepo-api-x-indexing</artifactId>
+      <version>${project.version}</version>
+      <classifier>features</classifier>
+      <type>xml</type>
+    </dependency>
+
   </dependencies>
 </project>

--- a/fcrepo-api-x-karaf/src/main/feature/feature.xml
+++ b/fcrepo-api-x-karaf/src/main/feature/feature.xml
@@ -4,6 +4,8 @@
   xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
   <repository>mvn:org.apache.camel.karaf/apache-camel/${camel.version}/xml/features</repository>
   <repository>mvn:org.apache.activemq/activemq-karaf/${activemq.version}/xml/features</repository>
+  <repository>mvn:org.fcrepo.camel/fcrepo-camel/${fcrepo-camel.version}/xml/features</repository>
+  <repository>mvn:org.fcrepo.camel/toolbox-features/${fcrepo-toolbox.version}/xml/features</repository>
   <feature name="fcrepo-api-x" description="All of api-x"
     version="${project.version}">
     <feature version="${project.version}">fcrepo-api-x-binding</feature>

--- a/fcrepo-api-x-routing/src/test/java/org/fcrepo/apix/routing/impl/ServiceDocumentGeneratorTest.java
+++ b/fcrepo-api-x-routing/src/test/java/org/fcrepo/apix/routing/impl/ServiceDocumentGeneratorTest.java
@@ -28,7 +28,7 @@ import static org.fcrepo.apix.model.Ontologies.Service.PROP_IS_FUNCTION_OF;
 import static org.fcrepo.apix.model.Ontologies.Service.PROP_IS_SERVICE_DOCUMENT_FOR;
 import static org.fcrepo.apix.model.Ontologies.Service.PROP_IS_SERVICE_INSTANCE_OF;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -46,6 +46,7 @@ import org.fcrepo.apix.model.WebResource;
 import org.fcrepo.apix.model.components.ExtensionBinding;
 import org.fcrepo.apix.model.components.Routing;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -193,7 +194,33 @@ public class ServiceDocumentGeneratorTest {
                 .mapWith(
                         Resource::getURI).toList();
         assertEquals(1, subjects.size());
-        assertNotEquals(SERVICE_DOC_URI, subjects.get(0));
+
+        assertFalse(IOUtils.toString(toTest.getServiceDocumentFor(RESOURCE_URI, "text/turtle").representation(),
+                "utf8").contains(SERVICE_DOC_URI));
+
+        toTest.setRelativeURIs(false);
+
+        assertTrue(IOUtils.toString(toTest.getServiceDocumentFor(RESOURCE_URI, "text/turtle").representation(),
+                "utf8").contains(SERVICE_DOC_URI));
+    }
+
+    // ntriples by definition uses absolute URIs. Verify that this is the case despite "useRelativeURI" setting
+    @Test
+    public void nTriplesTest() throws Exception {
+        final String SERVICE_DOC_URI = "test:/doc";
+        when(routing.serviceDocFor(RESOURCE_URI)).thenReturn(URI.create(SERVICE_DOC_URI));
+
+        toTest.setRelativeURIs(true);
+
+        assertTrue(IOUtils.toString(toTest.getServiceDocumentFor(RESOURCE_URI, "application/n-triples")
+                .representation(),
+                "utf8").contains(SERVICE_DOC_URI));
+
+        toTest.setRelativeURIs(false);
+
+        assertTrue(IOUtils.toString(toTest.getServiceDocumentFor(RESOURCE_URI, "application/n-triples")
+                .representation(),
+                "utf8").contains(SERVICE_DOC_URI));
     }
 
     // Verify that each exposing extension results a service instance,

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,7 @@
     <module>fcrepo-api-x-test</module>
     <module>fcrepo-api-x-listener</module>
     <module>fcrepo-api-x-loader</module>
+    <module>fcrepo-api-x-indexing</module>
   </modules>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
     <commons-io.version>2.5</commons-io.version>
     <docker>false</docker>
     <fcrepo.version>4.6.0</fcrepo.version>
+    <fcrepo-camel.version>4.4.4</fcrepo-camel.version>
+    <fcrepo-toolbox.version>4.6.1</fcrepo-toolbox.version>
     <fcrepo-build-tools.version>4.4.2</fcrepo-build-tools.version>
     <fcrepo.client.version>0.2.1</fcrepo.client.version>
     <httpclient.version>4.5.2</httpclient.version>


### PR DESCRIPTION
This contains camel routes to:
- index the service documents of resources that are added/updated/deleted
- launch a re-index whenever extension definitions are modified

These routes are good enough for the demo, but are not particularly optimized

Until dependency conflicts with `fcrepo-camel` are resolved, this PR contains a copied version of `SparqlUpdateProcessor` that uses Jena 3.x.   The sparql update processor in `fcrepo-camel` depends on Jena 2.13.  When deployed in the same Karaf container as API-X (which uses 3.10), bizarre stack traces like the below are observed.  Copying SparqlUpdateProcessor is a quick hack workaround.

<pre>
Caused by: java.lang.NoClassDefFoundError: Could not initialize class org.apache.jena.riot.system.RiotLib
        at org.apache.jena.riot.RiotReader.createParserNTriples(RiotReader.java:416)
        at org.apache.jena.riot.RiotReader.createParser(RiotReader.java:175)
        at org.apache.jena.riot.RiotReader.createParser(RiotReader.java:141)
        at org.apache.jena.riot.RDFParserRegistry$ReaderRIOTLang.read(RDFParserRegistry.java:180)
        at org.apache.jena.riot.RDFDataMgr.process(RDFDataMgr.java:906)
        at org.apache.jena.riot.RDFDataMgr.read(RDFDataMgr.java:257)
        at org.apache.jena.riot.RDFDataMgr.read(RDFDataMgr.java:243)
        <b>at org.apache.jena.riot.adapters.RDFReaderRIOT.read(RDFReaderRIOT.java:70)
        at com.hp.hpl.jena.rdf.model.impl.ModelCom.read(ModelCom.java:277)</b>
        at org.fcrepo.camel.processor.SparqlUpdateProcessor.process(SparqlUpdateProcessor.java:54)[147:org.fcrepo.camel.fcrepo-camel:4.4.4]
        at org.apache.camel.processor.DelegateSyncProcessor.process(DelegateSyncProcessor.java:63)
</pre>
