### PR TITLE
Allow for bypassing initialization when registry implementations/back…

### DIFF
--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/LdpContainerRegistry.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/LdpContainerRegistry.java
@@ -108,19 +108,24 @@ public class LdpContainerRegistry implements Registry {
      */
     public void init() {
 
+        if (!create) {
+            return;
+        }
+
         boolean found = false;
 
         while (!found) {
             try {
                 found = exists(containerId);
 
-                if (create && !found) {
+                if (!found) {
                     put(WebResource.of(initialContent(), "text/turtle",
                             containerId, null), false);
                     found = true;
                 }
             } catch (final Exception e) {
-                LOG.info("Failed initializing underlying container, re-trying..", e.getMessage());
+                LOG.warn("Failed initializing underlying container ('" + containerId + "'), re-trying ...",
+                        e.getMessage());
                 try {
                     Thread.sleep(1000);
                 } catch (final InterruptedException i) {

--- a/fcrepo-api-x-jena/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-jena/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -25,6 +25,7 @@
       <cm:property name="registry.ontology.content" value="null" />
       <cm:property name="registry.service.content"
         value="classpath:/objects/service-registry.ttl" />
+      <cm:property name="registry.ontology.index" value="true" />
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -79,6 +80,7 @@
   <bean id="jenaOntologyRegistryImpl" class="org.fcrepo.apix.jena.impl.LookupOntologyRegistry"
     init-method="init">
     <property name="registryDelegate" ref="ldpOntologyServiceRegistryDelegate" />
+    <property name="indexIRIs" value="${registry.ontology.index}" />
   </bean>
 
   <bean id="jenaServiceRegistryImpl" class="org.fcrepo.apix.jena.impl.JenaServiceRegistry">

--- a/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LdpContainerRegistryTest.java
+++ b/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LdpContainerRegistryTest.java
@@ -175,13 +175,11 @@ public class LdpContainerRegistryTest {
     public void noCreateTest() throws Exception {
         final LdpContainerRegistry toTest = new LdpContainerRegistry();
 
-        when(client.execute(isA(HttpHead.class))).thenReturn(headResponse);
-        when(headStatus.getStatusCode()).thenReturn(HttpStatus.SC_OK);
-
         toTest.setCreateContainer(false);
         toTest.setHttpClient(client);
         toTest.init();
 
+        verify(client, never()).execute(isA(HttpHead.class));
         verify(client, never()).execute(isA(HttpPut.class));
     }
 

--- a/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistryTest.java
+++ b/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistryTest.java
@@ -21,6 +21,8 @@ package org.fcrepo.apix.jena.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
+
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -156,6 +158,17 @@ public class LookupOntologyRegistryTest {
         toTest.setRegistryDelegate(delegate);
 
         initializing.get(2, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testNoIndexIRIs() throws Exception {
+        final LookupOntologyRegistry toTest = new LookupOntologyRegistry();
+
+        toTest.setRegistryDelegate(delegate);
+        toTest.setIndexIRIs(false);
+        toTest.init();
+
+        verifyZeroInteractions(delegate);
     }
 
     private class ReadableResource implements WebResource {


### PR DESCRIPTION
…-ends are not available.  Addresses #62. 
- Raises log level and detail when failing to intialize the LdpContainerRegistry
- Adds 'indexIRIs' to LookupOntologyRegistry
