### PR TITLE
Add apix.listen.host property (defaults to 0.0.0.0), controlling whic…

### DIFF
--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
@@ -128,17 +128,17 @@ public class RoutingImpl extends RouteBuilder {
 
         // It would be nice to use the rest DSL to do the service doc, if that is at all possible
 
-        from("jetty:http://{{apix.host}}:{{apix.port}}/{{apix.discoveryPath}}?matchOnUriPrefix=true")
+        from("jetty:http://{{apix.listen.host}}:{{apix.port}}/{{apix.discoveryPath}}?matchOnUriPrefix=true")
                 .process(WRITE_SERVICE_DOC);
 
-        from("jetty:http://{{apix.host}}:{{apix.port}}/{{apix.exposePath}}?matchOnUriPrefix=true")
+        from("jetty:http://{{apix.listen.host}}:{{apix.port}}/{{apix.exposePath}}?matchOnUriPrefix=true")
                 .routeId("endpoint-expose").routeDescription("Endpoint for exposed service mediation")
                 .process(ANALYZE_URI)
                 .choice()
                 .when(header(EXPOSING_EXTENSION).isNull()).to(EXTENSION_NOT_FOUND)
                 .otherwise().to(EXECUTION_EXPOSE_MODALITY);
 
-        from("jetty:http://{{apix.host}}:{{apix.port}}/{{apix.interceptPath}}?matchOnUriPrefix=true")
+        from("jetty:http://{{apix.listen.host}}:{{apix.port}}/{{apix.interceptPath}}?matchOnUriPrefix=true")
                 .routeId("endpoint-intercept").routeDescription("Endpoint for intercept/proxy to Fedora")
                 .to(ROUTE_INTERCEPT_INCOMING)
                 .choice().when(e -> !e.getIn().getHeaders().containsKey(

--- a/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,6 +15,7 @@
     <cm:default-properties>
       <cm:property name="apix.host" value="127.0.0.1" />
       <cm:property name="apix.port" value="8081" />
+      <cm:property name="apix.listen.host" value="0.0.0.0" />
       <cm:property name="apix.discoveryPath" value="discovery" />
       <cm:property name="apix.exposePath" value="services" />
       <cm:property name="apix.interceptPath" value="fcrepo/rest" />


### PR DESCRIPTION
…h host address API-X attempts to bind to.  Distinct from the apix.host property, which is used to generate URIs.