### PR TITLE
Bump to Fedora 4.7.0

### DIFF
--- a/fcrepo-api-x-integration/pom.xml
+++ b/fcrepo-api-x-integration/pom.xml
@@ -102,7 +102,7 @@
             <type>installed</type>
             <systemProperties>
               <fcrepo.home>${project.build.directory}/fcrepo</fcrepo.home>
-              <fcrepo.modeshape.configuration>classpath:/config/minimal-default/repository.json</fcrepo.modeshape.configuration>
+              <fcrepo.modeshape.configuration>classpath:/config/file-simple/repository.json</fcrepo.modeshape.configuration>
               <fcrepo.dynamic.jms.port>${fcrepo.dynamic.jms.port}</fcrepo.dynamic.jms.port>
               <fcrepo.dynamic.stomp.port>${fcrepo.dynamic.stomp.port}</fcrepo.dynamic.stomp.port>
             </systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.7.0</version>
   </parent>
 
   <groupId>org.fcrepo.apix</groupId>
@@ -24,7 +24,7 @@
     <commons-io.version>2.5</commons-io.version>
     <docker>false</docker>
     <dexx-collection.version>0.6</dexx-collection.version>
-    <fcrepo.version>4.6.0</fcrepo.version>
+    <fcrepo.version>4.7.0</fcrepo.version>
     <fcrepo-camel.version>4.4.4</fcrepo-camel.version>
     <fcrepo-toolbox.version>4.6.1</fcrepo-toolbox.version>
     <fcrepo-build-tools.version>4.4.2</fcrepo-build-tools.version>


### PR DESCRIPTION
Integration tests now run against 4.7.0, up from 4.6.0.  
Parent pom is no longer a -SNAPSHOT