### PR TITLE
Clean up exposed service configuration

### DIFF
--- a/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderRoutes.java
+++ b/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderRoutes.java
@@ -81,8 +81,7 @@ public class LoaderRoutes extends RouteBuilder {
                 .setHeader("Accept", constant("text/turtle"))
                 .to("jetty:http://localhost")
                 .process(DEPOSIT_OBJECTS)
-                .setHeader(HTTP_RESPONSE_CODE, constant(303))
-                .setHeader("Location", constant("http://example.org"));
+                .setHeader(HTTP_RESPONSE_CODE, constant(303));
 
         from(ROUTE_NO_SERVICE)
                 .setBody(constant("No service URI provided"))

--- a/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderService.java
+++ b/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderService.java
@@ -195,7 +195,7 @@ public class LoaderService {
                 LOG.debug("Service registry contains <{}>, NOT adding", canonical);
                 resolvableservices.add(canonical);
             } else {
-                LOG.debug("Service registry DOES NOT contain <{}>, adding!", canonical);
+                LOG.info("Service registry does not contain <{}>, adding!", canonical);
                 resolvableservices.add(putService(canonical));
             }
         }
@@ -213,6 +213,7 @@ public class LoaderService {
             instances = serviceRegistry.createInstanceRegistry(service);
         }
 
+        LOG.info("Adding endpoint <{}> as instance of <{}>", instanceURI, service.canonicalURI());
         return instances.addEndpoint(instanceURI);
     }
 

--- a/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Routing.java
+++ b/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Routing.java
@@ -39,13 +39,22 @@ public interface Routing {
     public static final String HTTP_HEADER_REPOSITORY_ROOT_URI = "Apix-Ldp-Root";
 
     /**
-     * /** Get the endpoint for the service exposed by the given extension on the given resource.
+     * Get the endpoint for the service exposed by the given extension on the given resource.
      *
      * @param spec specification for exposing a service
      * @param onResource the resource on which the service is exposed.
      * @return URI of exposed service, null if not applicable.
      */
     public URI endpointFor(ServiceExposureSpec spec, URI onResource);
+
+    /**
+     * Get the endpoint for the service exposed by the given extension on the given resource path.
+     *
+     * @param spec specification for exposing a service
+     * @param path path of the resource on which the service is exposed.
+     * @return URI of exposed service, null if not applicable.
+     */
+    public URI endpointFor(ServiceExposureSpec spec, String path);
 
     /**
      * Get the endpoint for the service doc of a given resource.

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingStub.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingStub.java
@@ -106,17 +106,22 @@ public class RoutingStub implements Routing {
     }
 
     @Override
-    public URI endpointFor(final ServiceExposureSpec spec, final URI onResource) {
+    public URI endpointFor(final ServiceExposureSpec spec, final String path) {
         switch (spec.scope()) {
         case EXTERNAL:
             return spec.exposedAt();
         case REPOSITORY:
             return append(baseURI(), exposePath, "", spec.exposedAt().getPath());
         case RESOURCE:
-            return append(baseURI(), exposePath, resourcePath(onResource), spec.exposedAt());
+            return append(baseURI(), exposePath, path, spec.exposedAt());
         default:
             throw new RuntimeException("Unknown service exposure scope " + spec.scope());
         }
+    }
+
+    @Override
+    public URI endpointFor(final ServiceExposureSpec spec, final URI onResource) {
+        return endpointFor(spec, resourcePath(onResource));
     }
 
     @Override

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ServiceDocumentGenerator.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ServiceDocumentGenerator.java
@@ -230,7 +230,6 @@ public class ServiceDocumentGenerator implements ServiceDiscovery {
     }
 
     private static Lang pickMediaType(final String... type) {
-        System.out.println(type);
 
         final List<Lang> langs = Arrays.stream(type)
                 .map(t -> "text/*".equals(t) ? "text/turtle" : t)

--- a/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -46,8 +46,8 @@
   <bean id="exposedServiceUriAnalyzer" class="org.fcrepo.apix.routing.impl.ExposedServiceUriAnalyzer">
     <property name="extensionRegistry" ref="extensionRegistry" />
     <property name="fcrepoBaseURI" value="${fcrepo.baseURI}" />
-    <property name="exposeBaseURI"
-      value="http://${apix.host}:${apix.port}/${apix.exposePath}" />
+    <property name="exposePath" value="${apix.exposePath}" />
+    <property name="routing" ref="routingStub" />
   </bean>
 
   <bean id="routingImpl" class="org.fcrepo.apix.routing.impl.RoutingImpl">


### PR DESCRIPTION
Existing configuration hardwired `http://{$apix.host}:${apix.port}` in the
exposed service base URI, conflicting with e1d4489 (#71).  This commit
defers to the Routing component to determine the correct exposed service
baseURI.

Resolves #78