### PR TITLE
Separately configure proxy and intercept paths

### DIFF
--- a/fcrepo-api-x-integration/src/test/resources/cfg/edu.amherst.acdc.exts.jsonld.cfg
+++ b/fcrepo-api-x-integration/src/test/resources/cfg/edu.amherst.acdc.exts.jsonld.cfg
@@ -1,0 +1,5 @@
+fcrepo.baseUrl=http://localhost:${fcrepo.dynamic.test.port}/${fcrepo.cxtPath}/rest
+jsonld.context=https://acdc.amherst.edu/jsonld/context.json
+rest.port=${services.dynamic.test.port}
+rest.host=localhost
+rest.prefix=/jsonld

--- a/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.routing.cfg
+++ b/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.routing.cfg
@@ -1,2 +1,3 @@
 fcrepo.baseURI = http://localhost:${fcrepo.dynamic.test.port}/${fcrepo.cxtPath}/rest
+fcrepo.proxyURI = http://localhost:${fcrepo.dynamic.test.port}/${fcrepo.cxtPath}
 apix.port = ${apix.dynamic.test.port}

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/GenericInterceptExecution.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/GenericInterceptExecution.java
@@ -75,7 +75,7 @@ public class GenericInterceptExecution extends RouteBuilder implements Updateabl
 
     private ServiceRegistry serviceRegistry;
 
-    private URI fcrepoBaseURI;
+    private URI proxyURI;
 
     /**
      * Set the extension binding.
@@ -109,8 +109,8 @@ public class GenericInterceptExecution extends RouteBuilder implements Updateabl
      *
      * @param uri the base URI.
      */
-    public void setFcrepoBaseURI(final URI uri) {
-        this.fcrepoBaseURI = uri;
+    public void setProxyURI(final URI uri) {
+        this.proxyURI = uri;
     }
 
     private final Collection<Extension> extensions = new ConcurrentHashSet<>();
@@ -158,7 +158,7 @@ public class GenericInterceptExecution extends RouteBuilder implements Updateabl
     }
 
     final Processor GET_INCOMING_ENDPOINTS = (ex -> {
-        final URI fedoraResource = append(fcrepoBaseURI, ex.getIn().getHeader(Exchange.HTTP_PATH));
+        final URI fedoraResource = append(proxyURI, ex.getIn().getHeader(Exchange.HTTP_PATH));
 
         if (extensions.size() > 0) {
             ex.getIn().setHeader(HEADER_SERVICE_ENDPOINTS,

--- a/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,6 +19,8 @@
       <cm:property name="apix.discoveryPath" value="discovery" />
       <cm:property name="apix.exposePath" value="services" />
       <cm:property name="apix.interceptPath" value="fcrepo/rest" />
+      <cm:property name="apix.proxyPath" value="fcrepo" />
+      <cm:property name="fcrepo.proxyURI" value="http://localhost:8080/fcrepo" />
       <cm:property name="fcrepo.baseURI" value="http://localhost:8080/fcrepo/rest" />
       <cm:property name="discovery.relativeURIs" value="true" />
       <cm:property name="discovery.interceptURIs" value="true" />
@@ -56,10 +58,12 @@
     <property name="serviceRegistry" ref="serviceRegistry" />
     <property name="exposedServiceURIAnalyzer" ref="exposedServiceUriAnalyzer" />
     <property name="routing" ref="routingStub" />
+    <property name="interceptPath" value="${apix.interceptPath}" />
+    <property name="proxyPath" value="${apix.proxyPath}" />
   </bean>
 
   <bean id="interceptImpl" class="org.fcrepo.apix.routing.impl.GenericInterceptExecution">
-    <property name="fcrepoBaseURI" value="${fcrepo.baseURI}" />
+    <property name="proxyURI" value="${fcrepo.proxyURI}" />
     <property name="extensionBinding" ref="extensionBinding" />
     <property name="serviceRegistry" ref="serviceRegistry" />
     <property name="extensionRegistry" ref="extensionRegistry" />


### PR DESCRIPTION
Make a distinction between proxy path and intercept path.  Proxy paths are
proxied, but do not go through the intercept processing.  Intercept paths
do both.  For Fedora repository, proxying /fcrepo but intercepting
/fcrepo/rest allows static resources in the html UI (.js files, icons,
etc) to be proxied, but not intercepted.

Resolves #74