### PR TITLE
Add resource path header for exposed services

### DIFF
--- a/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Routing.java
+++ b/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/Routing.java
@@ -32,6 +32,9 @@ public interface Routing {
     /** Fedora repository resource relevant to a resource-scoped exposed service */
     public static final String HTTP_HEADER_REPOSITORY_RESOURCE_URI = "Apix-Ldp-Resource";
 
+    /** Fedora repository resource path relevant to a resource-scoped exposed service */
+    public static final String HTTP_HEADER_REPOSITORY_RESOURCE_PATH = "Apix-Ldp-Resource-Path";
+
     /** Repository or resource-scoped exposed service URI */
     public static final String HTTP_HEADER_EXPOSED_SERVICE_URI = "Apix-Exposed-Uri";
 

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzer.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzer.java
@@ -148,6 +148,7 @@ public class ExposedServiceUriAnalyzer implements Updateable {
                     extension,
                     resourcePath != null ? append(fcrepoBaseURI, resourcePath) : null,
                     exposedServiceURI,
+                    resourcePath,
                     requestURI.toString().replace(exposedServiceURI.toString(), ""));
 
         } else {
@@ -166,6 +167,8 @@ public class ExposedServiceUriAnalyzer implements Updateable {
 
         public String additionalPath;
 
+        public String resourcePath;
+
         /**
          * Create a concrete binding
          *
@@ -175,11 +178,13 @@ public class ExposedServiceUriAnalyzer implements Updateable {
          * @param additionalPath Additional path segments from request.
          */
         public ServiceExposingBinding(final Extension extension, final URI resource, final URI exposed,
+                final String resourcePath,
                 final String additionalPath) {
             this.extension = extension;
             this.repositoryResourceURI = resource;
             this.baseURI = exposed;
             this.additionalPath = additionalPath;
+            this.resourcePath = resourcePath;
         }
 
         /**

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
@@ -19,6 +19,7 @@
 package org.fcrepo.apix.routing.impl;
 
 import static org.fcrepo.apix.model.components.Routing.HTTP_HEADER_EXPOSED_SERVICE_URI;
+import static org.fcrepo.apix.model.components.Routing.HTTP_HEADER_REPOSITORY_RESOURCE_PATH;
 import static org.fcrepo.apix.model.components.Routing.HTTP_HEADER_REPOSITORY_RESOURCE_URI;
 import static org.fcrepo.apix.model.components.Routing.HTTP_HEADER_REPOSITORY_ROOT_URI;
 import static org.fcrepo.apix.routing.Util.append;
@@ -183,6 +184,7 @@ public class RoutingImpl extends RouteBuilder {
         // resource URI is only conveyed for resource-scope services
         if (Scope.RESOURCE.equals(binding.extension.exposed().scope())) {
             ex.getIn().setHeader(HTTP_HEADER_REPOSITORY_RESOURCE_URI, binding.repositoryResourceURI);
+            ex.getIn().setHeader(HTTP_HEADER_REPOSITORY_RESOURCE_PATH, binding.resourcePath);
         } else {
             ex.getIn().setHeader(HTTP_HEADER_REPOSITORY_ROOT_URI, fcrepoBaseURI);
         }


### PR DESCRIPTION
To facilitate services that might need a Fedora resource *path*, rather
than a URI, a new header Apix-Ldp-Resource-Path has been added