### PR TITLE
Use http4 component with streaming

### DIFF
--- a/fcrepo-api-x-integration/pom.xml
+++ b/fcrepo-api-x-integration/pom.xml
@@ -287,6 +287,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Fedora -->
     <dependency>
       <groupId>org.fcrepo</groupId>

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/LoaderIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/LoaderIT.java
@@ -144,6 +144,7 @@ public class LoaderIT extends ServiceBasedTest {
     public void setUp() {
 
         onServiceRequest(ex -> {
+            ex.setOut(ex.getIn());
             if ("OPTIONS".equals(ex.getIn().getHeader(Exchange.HTTP_METHOD))) {
                 ex.getOut().setBody(optionsResponse.get());
             } else if ("GET".equals(ex.getIn().getHeader(Exchange.HTTP_METHOD))) {

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/MyIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/MyIT.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.apix.integration;
+
+
+/**
+ *
+ * @author apb@jhu.edu
+ */
+public class MyIT implements KarafIT {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String testClassName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String testMethodName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceBasedTest.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceBasedTest.java
@@ -135,11 +135,12 @@ public abstract class ServiceBasedTest implements KarafIT {
                 from("jetty:" + serviceEndpoint +
                         "?matchOnUriPrefix=true")
                                 .process(ex -> {
-                                    ex.getOut().copyFrom(responseFromService);
                                     requestToService.copyFrom(ex.getIn());
 
                                     if (processFromTest != null) {
                                         processFromTest.process(ex);
+                                    } else {
+                                        ex.getOut().copyFrom(responseFromService);
                                     }
 
                                 });

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/StreamingIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/StreamingIT.java
@@ -127,7 +127,7 @@ public class StreamingIT implements KarafIT {
         }
 
         // Create the binary resource if it doesn't already exist
-        URI expectedBinaryResource = appendToPath(binaryContainer, "large-binary");
+        final URI expectedBinaryResource = appendToPath(binaryContainer, "large-binary");
         if (!resourceExists(expectedBinaryResource)) {
             LOG.warn("Expected resource did not exist {}", expectedBinaryResource);
             try {
@@ -177,7 +177,7 @@ public class StreamingIT implements KarafIT {
     public void testRetrieveLargeBinaryFromFedora() throws Exception {
 
         // Record 'true' if the intercepting route is triggered
-        AtomicBoolean intercepted = new AtomicBoolean(false);
+        final AtomicBoolean intercepted = new AtomicBoolean(false);
         ctx.getRouteDefinition(INTERCEPT_ROUTE_ID).adviceWith((ModelCamelContext) ctx, new AdviceWithRouteBuilder() {
             @Override
             public void configure() throws Exception {
@@ -185,9 +185,9 @@ public class StreamingIT implements KarafIT {
             }
         });
 
-        long expectedSize = (2 * 1024 * 1024) + 1;
-        long actualSize;
-        String actualDigest;
+        final long expectedSize = (2 * 1024 * 1024) + 1;
+        final long actualSize;
+        final String actualDigest;
 
         try (FcrepoResponse r = client.get(binaryResource).perform();
              DigestInputStream body = new DigestInputStream(r.getBody(), sha1)) {
@@ -214,7 +214,7 @@ public class StreamingIT implements KarafIT {
     public void testRetrieveLargeBinaryFromApix() throws Exception {
 
         // Record 'true' if the intercepting route is triggered
-        AtomicBoolean intercepted = new AtomicBoolean(false);
+        final AtomicBoolean intercepted = new AtomicBoolean(false);
         ctx.getRouteDefinition(INTERCEPT_ROUTE_ID).adviceWith((ModelCamelContext) ctx, new AdviceWithRouteBuilder() {
             @Override
             public void configure() throws Exception {
@@ -222,9 +222,9 @@ public class StreamingIT implements KarafIT {
             }
         });
 
-        long expectedSize = (2 * 1024 * 1024) + 1;
-        long actualSize;
-        String actualDigest;
+        final long expectedSize = (2 * 1024 * 1024) + 1;
+        final long actualSize;
+        final String actualDigest;
 
         final URI proxiedResource = proxied(binaryResource);
         try (FcrepoResponse r = KarafIT.attempt(30, () -> client.get(proxiedResource).perform());
@@ -249,7 +249,7 @@ public class StreamingIT implements KarafIT {
      * @return true if the resource exists, false otherwise
      * @throws IOException if there is an error determining whether the resource exists
      */
-    private boolean resourceExists(URI resource) throws IOException {
+    private boolean resourceExists(final URI resource) throws IOException {
         try (FcrepoResponse r = client.head(resource).perform()) {
             if (r.getStatusCode() == 200) {
                 return true;
@@ -269,8 +269,8 @@ public class StreamingIT implements KarafIT {
      * @return the number of bytes read
      * @throws IOException
      */
-    private static long drain(InputStream in) throws IOException {
-        byte[] buf = new byte[1024 * 128];
+    private static long drain(final InputStream in) throws IOException {
+        final byte[] buf = new byte[1024 * 128];
         long size = 0;
 
         for (int i = in.read(buf, 0, buf.length); i > -1; i = in.read(buf, 0, i)) {
@@ -286,8 +286,8 @@ public class StreamingIT implements KarafIT {
      * @param digest a byte array containing a message digest
      * @return a hexadecimal string representation of the message digest
      */
-    private static String asHex(byte[] digest) {
-        StringBuilder buf = new StringBuilder();
+    private static String asHex(final byte[] digest) {
+        final StringBuilder buf = new StringBuilder();
         for (int i = 0; i < digest.length; i++) {
             buf.append(
                     String.format("%02x", Byte.toUnsignedInt(digest[i])));
@@ -304,7 +304,7 @@ public class StreamingIT implements KarafIT {
      * @return an equivalent URI targeting the proxied Fedora resource
      * @throws URISyntaxException
      */
-    private static URI proxied(URI toProxy) throws URISyntaxException {
+    private static URI proxied(final URI toProxy) throws URISyntaxException {
         if (isProxied(toProxy)) {
             return toProxy;
         }
@@ -319,7 +319,7 @@ public class StreamingIT implements KarafIT {
      * @return a new URI with a path component ending with {@code toAppend}
      * @throws URISyntaxException
      */
-    private static URI appendToPath(URI uri, String toAppend) throws URISyntaxException {
+    private static URI appendToPath(final URI uri, final String toAppend) throws URISyntaxException {
         return new URI(uri.getScheme(),
                 uri.getUserInfo(),
                 uri.getHost(),

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/StreamingIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/StreamingIT.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.integration;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.model.ModelCamelContext;
+import org.apache.commons.io.input.NullInputStream;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.fcrepo.client.FcrepoOperationFailedException;
+import org.fcrepo.client.FcrepoResponse;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.util.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Integration tests relating to streaming content proxied by API-X
+ *
+ * @author esm
+ */
+@RunWith(PaxExam.class)
+public class StreamingIT implements KarafIT {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StreamingIT.class);
+
+    private static final URI APIX_BASE_URI = URI.create(apixBaseURI);
+
+    private static final String INTERCEPT_ROUTE_ID = "execute-intercept";
+
+    private static final String CONTEXT_NAME = "apix-core";
+
+    private static final String CONTEXT_ROLE = "routing-context";
+
+    private URI binaryContainer;
+
+    private URI binaryResource;
+
+    private String binaryResourceSha;
+
+    private static MessageDigest sha1;
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Inject
+    @Filter("(role=" + CONTEXT_ROLE + ")")
+    private CamelContext ctx;
+
+    @Override
+    public String testClassName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public String testMethodName() {
+        return name.getMethodName();
+    }
+
+    @BeforeClass
+    public static void initMessageDigest() throws NoSuchAlgorithmException {
+        sha1 = MessageDigest.getInstance("SHA-1");
+    }
+
+    /**
+     * Creates a container and a binary resource of 2MiB + 1 bytes long.  Retrieves checksum of the resource.
+     *
+     * @throws FcrepoOperationFailedException if unexpected things go wrong
+     * @throws IOException if unexpected things go wrong
+     * @throws URISyntaxException if unexpected things go wrong
+     */
+    @Before
+    public void initBinaryResources() throws FcrepoOperationFailedException, IOException, URISyntaxException {
+        binaryContainer = URI.create(String.format("%s%s", fcrepoBaseURI, testClassName() + "/binaries/"));
+
+        // Create container if it doesn't already exist
+        if (!resourceExists(binaryContainer)) {
+            try (FcrepoResponse r = client.put(binaryContainer)
+                    .body(
+                            new FileInputStream(
+                                    new File(testResources, "objects/binary_container.ttl")), "text/turtle")
+                    .perform()) {
+                assertEquals("Failed to create binary container '" + binaryContainer + "'",
+                        201, r.getStatusCode());
+            }
+        }
+
+        // Create the binary resource if it doesn't already exist
+        URI expectedBinaryResource = appendToPath(binaryContainer, "large-binary");
+        if (!resourceExists(expectedBinaryResource)) {
+            LOG.warn("Expected resource did not exist {}", expectedBinaryResource);
+            try {
+                binaryResource = postFromStream(
+                        new NullInputStream((2 * 1024 * 1024) + 1), binaryContainer,
+                        "application/octet-stream", "large-binary");
+            } catch (Exception e) {
+                fail(String.format("Failed to create binary LDPR: %s", e.getMessage()));
+            }
+        } else {
+            binaryResource = expectedBinaryResource;
+        }
+
+        // Retrieve the checksum calculated by Fedora
+        binaryResourceSha = ModelFactory.createDefaultModel()
+                .read(client
+                        .get(appendToPath(binaryResource, "/fcr:metadata"))
+                        .accept("application/rdf+xml")
+                        .perform().getBody(),
+                            null)
+                .listObjectsOfProperty(
+                        ResourceFactory
+                                .createProperty("http://www.loc.gov/premis/rdf/v1#", "hasMessageDigest"))
+                .mapWith((digestValue) -> digestValue.toString().substring("urn:sha1:".length()))
+                .next();
+        assertNotNull("Missing http://www.loc.gov/premis/rdf/v1#hasMessageDigest on " +
+                appendToPath(binaryResource, "/fcr:metadata").toString(), binaryResourceSha);
+
+    }
+
+    /**
+     * Smoke test insuring Karaf is doing what we think it is doing
+     */
+    @Before
+    public void verifyContextAndRoute() {
+        assertNotNull("No context", ctx);
+        assertEquals("Unexpected context " + ctx.getName(), CONTEXT_NAME, ctx.getName());
+        assertNotNull("No route (ctx name: " + ctx.getName() + ")", ctx.getRouteDefinition(INTERCEPT_ROUTE_ID));
+    }
+
+    /**
+     * Verify the binary can be retrieved from Fedora.  The request should <em>not</em> be intercepted.
+     *
+     * @throws Exception if unexpected things go wrong
+     */
+    @Test
+    public void testRetrieveLargeBinaryFromFedora() throws Exception {
+
+        // Record 'true' if the intercepting route is triggered
+        AtomicBoolean intercepted = new AtomicBoolean(false);
+        ctx.getRouteDefinition(INTERCEPT_ROUTE_ID).adviceWith((ModelCamelContext) ctx, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                weaveAddFirst().process((ex) -> intercepted.set(true));
+            }
+        });
+
+        long expectedSize = (2 * 1024 * 1024) + 1;
+        long actualSize;
+        String actualDigest;
+
+        try (FcrepoResponse r = client.get(binaryResource).perform();
+             DigestInputStream body = new DigestInputStream(r.getBody(), sha1)) {
+            actualSize = drain(body);
+            actualDigest = asHex(body.getMessageDigest().digest());
+        }
+
+        // The resource can be retrieved intact
+        assertEquals(expectedSize, actualSize);
+        assertEquals(binaryResourceSha, actualDigest);
+
+        // And the request was not proxied by API-X
+        assertFalse(String.format("Unexpected interception of a Fedora resource URI %s by route %s",
+                binaryResource.toString(), INTERCEPT_ROUTE_ID), intercepted.get());
+    }
+
+    /**
+     * Verify the binary can be retrieved through the API-X proxy.  The request should be intercepted and proxied
+     * by API-X.
+     *
+     * @throws Exception if unexpected things go wrong
+     */
+    @Test
+    public void testRetrieveLargeBinaryFromApix() throws Exception {
+
+        // Record 'true' if the intercepting route is triggered
+        AtomicBoolean intercepted = new AtomicBoolean(false);
+        ctx.getRouteDefinition(INTERCEPT_ROUTE_ID).adviceWith((ModelCamelContext) ctx, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                weaveAddFirst().process((ex) -> intercepted.set(true));
+            }
+        });
+
+        long expectedSize = (2 * 1024 * 1024) + 1;
+        long actualSize;
+        String actualDigest;
+
+        final URI proxiedResource = proxied(binaryResource);
+        try (FcrepoResponse r = KarafIT.attempt(30, () -> client.get(proxiedResource).perform());
+             DigestInputStream body = new DigestInputStream(r.getBody(), sha1)) {
+            actualSize = drain(body);
+            actualDigest = asHex(body.getMessageDigest().digest());
+        }
+
+        // The request _was_ proxied by API-X
+        assertTrue(String.format("Expected the retrieval of %s to be proxied by API-X, route id %s",
+                proxiedResource, INTERCEPT_ROUTE_ID), intercepted.get());
+
+        // And resource can be retrieved intact
+        assertEquals(expectedSize, actualSize);
+        assertEquals(binaryResourceSha, actualDigest);
+    }
+
+    /**
+     * Returns true if the URI exists (i.e. responds with a 200 to a HEAD request).
+     *
+     * @param resource some HTTP resource
+     * @return true if the resource exists, false otherwise
+     * @throws IOException if there is an error determining whether the resource exists
+     */
+    private boolean resourceExists(URI resource) throws IOException {
+        try (FcrepoResponse r = client.head(resource).perform()) {
+            if (r.getStatusCode() == 200) {
+                return true;
+            }
+        } catch (FcrepoOperationFailedException e) {
+            // Probably the resource doesn't exist.
+            LOG.debug("Error retrieving resource '" + resource + "': " + e.getMessage(), e);
+        }
+
+        return false;
+    }
+
+    /**
+     * Reads the input stream to exhaustion and returns the number of bytes read.
+     *
+     * @param in the stream to exhaust
+     * @return the number of bytes read
+     * @throws IOException
+     */
+    private static long drain(InputStream in) throws IOException {
+        byte[] buf = new byte[1024 * 128];
+        long size = 0;
+
+        for (int i = in.read(buf, 0, buf.length); i > -1; i = in.read(buf, 0, i)) {
+            size += i;
+        }
+
+        return size;
+    }
+
+    /**
+     * Coverts the supplied byte array to a String hexadecimal representation, starting with the most significant bit.
+     *
+     * @param digest a byte array containing a message digest
+     * @return a hexadecimal string representation of the message digest
+     */
+    private static String asHex(byte[] digest) {
+        StringBuilder buf = new StringBuilder();
+        for (int i = 0; i < digest.length; i++) {
+            buf.append(
+                    String.format("%02x", Byte.toUnsignedInt(digest[i])));
+        }
+
+        return buf.toString();
+    }
+
+    /**
+     * Assuming the supplied URI targets the <em>Fedora repository</em> (i.e. <em>a URI that is not proxied by
+     * API-X</em>), returns an equivalent URI that targets the same resource through the API-X proxy.
+     *
+     * @param toProxy a URI that targets an un-proxied Fedora resource
+     * @return an equivalent URI targeting the proxied Fedora resource
+     * @throws URISyntaxException
+     */
+    private static URI proxied(URI toProxy) throws URISyntaxException {
+        if (isProxied(toProxy)) {
+            return toProxy;
+        }
+        return appendToPath(APIX_BASE_URI, toProxy.getPath());
+    }
+
+    /**
+     * Appends the path to the URI.  All other components of the URI are preserved.
+     *
+     * @param uri      the URI with the path being appended to
+     * @param toAppend the path to be appended to the URI
+     * @return a new URI with a path component ending with {@code toAppend}
+     * @throws URISyntaxException
+     */
+    private static URI appendToPath(URI uri, String toAppend) throws URISyntaxException {
+        return new URI(uri.getScheme(),
+                uri.getUserInfo(),
+                uri.getHost(),
+                uri.getPort(),
+                uri.getPath() + toAppend,
+                uri.getRawQuery(),
+                uri.getRawFragment());
+    }
+
+    /**
+     * Returns true if the supplied URI will be proxied by API-X
+     *
+     * @param uri a candidate uri that might be proxied API-X
+     * @return true if the supplied URI will be proxied by API-X, false otherwise
+     */
+    private static boolean isProxied(final URI uri) {
+        return uri.getScheme().equals(APIX_BASE_URI.getScheme())
+                && uri.getHost().equals(APIX_BASE_URI.getHost())
+                && uri.getPort() == APIX_BASE_URI.getPort();
+    }
+
+}

--- a/fcrepo-api-x-integration/src/test/resources/objects/binary_container.ttl
+++ b/fcrepo-api-x-integration/src/test/resources/objects/binary_container.ttl
@@ -1,0 +1,3 @@
+@prefix ldp:<http://www.w3.org/ns/ldp#> .
+
+<> a ldp:Container , ldp:BasicContainer .

--- a/fcrepo-api-x-routing/pom.xml
+++ b/fcrepo-api-x-routing/pom.xml
@@ -51,6 +51,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-http4</artifactId>
+      <version>${camel.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>provided</scope>

--- a/fcrepo-api-x-routing/src/main/feature/feature.xml
+++ b/fcrepo-api-x-routing/src/main/feature/feature.xml
@@ -5,6 +5,7 @@
   <feature name="fcrepo-api-x-routing" description="fcrepo-api-x-routing"
     version="${project.version}">
     <feature version="${camel.version}">camel-blueprint</feature>
-    <feature version="${camel.version}">camel-jetty</feature>  
+    <feature version="${camel.version}">camel-jetty</feature>
+    <feature version="${camel.version}">camel-http4</feature>
   </feature>
 </features>

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/GenericInterceptExecution.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/GenericInterceptExecution.java
@@ -154,7 +154,7 @@ public class GenericInterceptExecution extends RouteBuilder implements Updateabl
                 .process(e -> e.getIn().setHeader(
                         Exchange.HTTP_URI,
                         e.getIn().getHeader(HEADER_SERVICE_ENDPOINTS, Queue.class).remove()))
-                .to("jetty://localhost?throwExceptionOnFailure=false");
+                .to("http://localhost?throwExceptionOnFailure=false");
     }
 
     final Processor GET_INCOMING_ENDPOINTS = (ex -> {

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
@@ -24,7 +24,6 @@ import static org.fcrepo.apix.model.components.Routing.HTTP_HEADER_REPOSITORY_RE
 import static org.fcrepo.apix.model.components.Routing.HTTP_HEADER_REPOSITORY_ROOT_URI;
 import static org.fcrepo.apix.routing.Util.append;
 import static org.fcrepo.apix.routing.Util.segment;
-import static org.fcrepo.apix.routing.impl.GenericInterceptExecution.HEADER_INVOKE_STATUS;
 import static org.fcrepo.apix.routing.impl.GenericInterceptExecution.ROUTE_INTERCEPT_INCOMING;
 import static org.fcrepo.apix.routing.impl.GenericInterceptExecution.ROUTE_INTERCEPT_OUTGOING;
 
@@ -72,6 +71,8 @@ public class RoutingImpl extends RouteBuilder {
     public static final String EXTENSION_NOT_FOUND = "direct:extension_not_found";
 
     public static final String ROUTE_INTERCEPT = "direct:intercept";
+
+    public static final String ROUTE_TO_FEDORA = "direct:fcrepo";
 
     public static final String BINDING = "CamelApixServiceExposureBinding";
 
@@ -182,21 +183,25 @@ public class RoutingImpl extends RouteBuilder {
                         .when(IN_INTERCEPT_PATH).to(ROUTE_INTERCEPT)
                         .otherwise().to("{{fcrepo.proxyURI}}" +
                                 "?bridgeEndpoint=true" +
+                                "&disableStreamCache=true" +
                                 "&throwExceptionOnFailure=false" +
                                 "&preserveHostHeader=true");
 
         from(ROUTE_INTERCEPT)
                 .routeId("execute-intercept").routeDescription("Endpoint for intercept to Fedora")
                 .to(ROUTE_INTERCEPT_INCOMING)
-                .choice().when(e -> !e.getIn().getHeaders().containsKey(
-                        HEADER_INVOKE_STATUS) || e.getIn().getHeader(
-                                HEADER_INVOKE_STATUS, Integer.class) < 300)
+                .choice().when(simple("${in.header.CamelhttpResponseCode} range '200..299'"))
+                .to(ROUTE_TO_FEDORA);
+
+        from(ROUTE_TO_FEDORA)
                 .to("{{fcrepo.proxyURI}}" +
                         "?bridgeEndpoint=true" +
                         "&throwExceptionOnFailure=false" +
-                        "&preserveHostHeader=true")
+                        "&disableStreamCache=true" +
+                        "&preserveHostHeader=true").end()
                 .process(ADD_SERVICE_HEADER)
-                .to(ROUTE_INTERCEPT_OUTGOING);
+                .choice().when(simple("${in.header.CamelhttpResponseCode} range '200..299'"))
+                .to(ROUTE_INTERCEPT_OUTGOING).end();
 
         from(EXTENSION_NOT_FOUND).id("not-found-extension").routeDescription("Extension not found")
                 .process(e -> e.getOut().setHeader(Exchange.HTTP_RESPONSE_CODE, 404));
@@ -206,11 +211,11 @@ public class RoutingImpl extends RouteBuilder {
                 .routeDescription("Proxies an exposed service to a service instance")
                 .process(SELECT_SERVICE_INSTANCE)
                 .setHeader(Exchange.HTTP_PATH).simple("${in.header." + BINDING + ".additionalPath}")
-                .recipientList(simple(
-                        "${in.header." + SERVICE_INSTANCE_URI + "}" +
-                                "?bridgeEndpoint=true" +
-                                "&preserveHostHeader=true" +
-                                "&throwExceptionOnFailure=false"));
+                .setHeader(Exchange.HTTP_URI).header(SERVICE_INSTANCE_URI)
+                .to("http://localhost" +
+                        "?preserveHostHeader=true" +
+                        "&disableStreamCache=true" +
+                        "&throwExceptionOnFailure=false");
 
     }
 

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
@@ -63,6 +63,8 @@ public class RoutingImpl extends RouteBuilder {
 
     private URI fcrepoBaseURI;
 
+    private URI fcrepoProxyURI;
+
     public static final String EXECUTION_EXPOSE_MODALITY = "direct:execute_expose";
 
     public static final String EXPOSING_EXTENSION = "CamelApixExposingExtension";
@@ -94,6 +96,14 @@ public class RoutingImpl extends RouteBuilder {
      */
     public void setFcrepoBaseURI(final URI uri) {
         this.fcrepoBaseURI = uri;
+    }
+
+    /**
+     * Fedora's proxyURI
+     * @param fcrepoProxyURI
+     */
+    public void setFcrepoProxyURI(final URI fcrepoProxyURI) {
+        this.fcrepoProxyURI = fcrepoProxyURI;
     }
 
     /**
@@ -186,7 +196,7 @@ public class RoutingImpl extends RouteBuilder {
                 .choice().when(e -> !e.getIn().getHeaders().containsKey(
                         HEADER_INVOKE_STATUS) || e.getIn().getHeader(
                                 HEADER_INVOKE_STATUS, Integer.class) < 300)
-                .to("jetty:{{fcrepo.proxyURI}}" +
+                .to("http4:" + stripHttpScheme(fcrepoProxyURI) +
                         "?bridgeEndpoint=true" +
                         "&throwExceptionOnFailure=false" +
                         "&disableStreamCache=true" +
@@ -301,6 +311,17 @@ public class RoutingImpl extends RouteBuilder {
         } else {
             return append(fcrepoBaseURI, resourcePath);
         }
+    }
+
+    private static String stripHttpScheme(URI uri) {
+        if (uri.getScheme().startsWith("http")) {
+            return uri.toString().substring("http://".length());
+        }
+
+        if (uri.getScheme().startsWith("https")) {
+            return uri.toString().substring("https://".length());
+        }
+        return uri.toString();
     }
 
     private static <T> T exactlyOne(final Collection<T> of, final String errMsg) {

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
@@ -100,6 +100,7 @@ public class RoutingImpl extends RouteBuilder {
 
     /**
      * Fedora's proxyURI
+     * 
      * @param fcrepoProxyURI
      */
     public void setFcrepoProxyURI(final URI fcrepoProxyURI) {
@@ -313,7 +314,7 @@ public class RoutingImpl extends RouteBuilder {
         }
     }
 
-    private static String stripHttpScheme(URI uri) {
+    private static String stripHttpScheme(final URI uri) {
         if (uri.getScheme().startsWith("http")) {
             return uri.toString().substring("http://".length());
         }

--- a/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -38,6 +38,9 @@
 
   <reference id="initializer" interface="org.fcrepo.apix.model.components.Initializer" />
 
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent" />
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent" />
+
   <bean id="routingStub" class="org.fcrepo.apix.routing.impl.RoutingStub">
     <property name="host" value="${apix.host}" />
     <property name="port" value="${apix.port}" />
@@ -58,7 +61,6 @@
 
   <bean id="routingImpl" class="org.fcrepo.apix.routing.impl.RoutingImpl">
     <property name="fcrepoBaseURI" value="${fcrepo.baseURI}" />
-    <property name="fcrepoProxyURI" value="${fcrepo.proxyURI}" />
     <property name="serviceDiscovery" ref="serviceDiscoveryImpl" />
     <property name="serviceRegistry" ref="serviceRegistry" />
     <property name="exposedServiceURIAnalyzer" ref="exposedServiceUriAnalyzer" />
@@ -100,7 +102,7 @@
 
   <service interface="org.apache.camel.CamelContext" ref="apix-core">
     <service-properties>
-      <entry key="role" value="routing-context"/>
+      <entry key="role" value="routing-context" />
     </service-properties>
   </service>
 

--- a/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -58,6 +58,7 @@
 
   <bean id="routingImpl" class="org.fcrepo.apix.routing.impl.RoutingImpl">
     <property name="fcrepoBaseURI" value="${fcrepo.baseURI}" />
+    <property name="fcrepoProxyURI" value="${fcrepo.proxyURI}" />
     <property name="serviceDiscovery" ref="serviceDiscoveryImpl" />
     <property name="serviceRegistry" ref="serviceRegistry" />
     <property name="exposedServiceURIAnalyzer" ref="exposedServiceUriAnalyzer" />
@@ -92,8 +93,15 @@
   <service id="interceptUpdate" interface="org.fcrepo.apix.model.components.Updateable"
     ref="interceptImpl" />
 
-  <camel:camelContext>
+  <camel:camelContext id="apix-core">
     <camel:routeBuilder ref="routingImpl" />
     <camel:routeBuilder ref="interceptImpl" />
   </camel:camelContext>
+
+  <service interface="org.apache.camel.CamelContext" ref="apix-core">
+    <service-properties>
+      <entry key="role" value="routing-context"/>
+    </service-properties>
+  </service>
+
 </blueprint>


### PR DESCRIPTION
The jetty producer has fundamental flaws and is incapable of streaming
http requests to endpoints; it relies on an easily-exceeded 2MB buffer.

The http4 component supports streaming out of the box, but Exchanges
that originate from http requests automatically close streams when their
lifecycle ends.  This means that certain Camel constructs that terminate
exchanges (e.g. `recipientList`, `enrich`, etc) must be avoided.  This is an 
undocumented gotcha in Camel.

Resolves #76 