### PR TITLE
Persist ontologies to registry

### DIFF
--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/OntologyIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/OntologyIT.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.integration;
+
+import static org.fcrepo.apix.jena.Util.parse;
+import static org.fcrepo.apix.model.Ontologies.RDF_TYPE;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.inject.Inject;
+
+import org.fcrepo.apix.model.WebResource;
+import org.fcrepo.apix.model.components.OntologyRegistry;
+import org.fcrepo.client.FcrepoResponse;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.rdf.model.Model;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+/**
+ * Verifies that imported ontologies in extensions are persisted, where desired.
+ *
+ * @author apb@jhu.edu
+ */
+@RunWith(PaxExam.class)
+public class OntologyIT extends ServiceBasedTest {
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Override
+    public String testClassName() {
+        return OntologyIT.class.getSimpleName();
+    }
+
+    @Inject
+    OntologyRegistry ontologyRegistry;
+
+    @Override
+    public String testMethodName() {
+        return name.getMethodName();
+    }
+
+    @BeforeClass
+    public static void init() throws Exception {
+        KarafIT.createContainers();
+    }
+
+    @Test
+    public void depositTest() throws Exception {
+
+        final URI ontologyIRI = URI.create(serviceEndpoint);
+        final String ontologyContent = String.format(
+                "<%s> a <http://www.w3.org/2002/07/owl#Ontology> .", ontologyIRI);
+
+        final AtomicBoolean ontologyFetched = new AtomicBoolean(false);
+
+        onServiceRequest(e -> {
+            e.getOut().setBody(ontologyContent);
+            e.getOut().setHeader("Content-Type", "text/turtle");
+            ontologyFetched.set(true);
+        });
+
+        try (FcrepoResponse response = client.post(extensionContainer)
+                .body(IOUtils.toInputStream(
+                        String.format("<> <http://www.w3.org/2002/07/owl#imports> <%s> .", ontologyIRI), "utf8"),
+                        "text/turtle").perform()) {
+
+            update();
+
+            assertTrue(ontologyFetched.get());
+
+            try (WebResource ontology = ontologyRegistry.get(ontologyIRI)) {
+                assertNotEquals(ontology.uri(), ontologyIRI);
+                final Model parsed = parse(ontology);
+                assertTrue(parsed.contains(parsed.getResource(ontologyIRI.toString()), parsed.getProperty(RDF_TYPE),
+                        parsed.getResource("http://www.w3.org/2002/07/owl#Ontology")));
+            }
+        }
+    }
+}

--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/Util.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/Util.java
@@ -74,17 +74,32 @@ public abstract class Util {
 
         final Model model =
                 ModelFactory.createDefaultModel();
-        model.setNsPrefix("", "");
 
-        final Lang lang = RDFLanguages.contentTypeToLang(r.contentType());
+        final Lang lang = rdfLanguage(r.contentType());
 
-        LOG.debug("Parsing rdf from {}", r.uri());
         try (InputStream representation = r.representation()) {
             RDFDataMgr.read(model, representation, base, lang);
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }
+
         return model;
+    }
+
+    /**
+     * Determine the jena language from a content type string
+     *
+     * @param contentType content type
+     * @return language
+     */
+    public static final Lang rdfLanguage(final String contentType) {
+        final int separator = contentType.indexOf(';');
+
+        if (separator < 0) {
+            return RDFLanguages.contentTypeToLang(contentType);
+        } else {
+            return RDFLanguages.contentTypeToLang(contentType.substring(0, separator));
+        }
     }
 
     /**
@@ -97,7 +112,7 @@ public abstract class Util {
      * @return The model
      */
     public static Model parse(final WebResource r) {
-        return parse(r, r.uri() != null ? r.uri().toString() : "");
+        return parse(r, r.uri() == null ? "" : r.uri().toString());
     }
 
     /**

--- a/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/PersistingOntologyRegistry.java
+++ b/fcrepo-api-x-jena/src/main/java/org/fcrepo/apix/jena/impl/PersistingOntologyRegistry.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.jena.impl;
+
+import java.net.URI;
+
+import org.fcrepo.apix.model.WebResource;
+import org.fcrepo.apix.model.components.ExtensionRegistry;
+import org.fcrepo.apix.model.components.OntologyRegistry;
+import org.fcrepo.apix.model.components.OntologyService;
+import org.fcrepo.apix.model.components.Registry;
+import org.fcrepo.apix.model.components.Updateable;
+
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Persists ontologies if not present in a registry.
+ *
+ * @author apb@jhu.edu
+ */
+public class PersistingOntologyRegistry extends WrappingRegistry implements OntologyRegistry, Updateable {
+
+    static final Logger LOG = LoggerFactory.getLogger(PersistingOntologyRegistry.class);
+
+    private boolean doPersist = true;
+
+    private OntologyRegistry delegate;
+
+    private OntologyService ontologyService;
+
+    private ExtensionRegistry extensionRegistry;
+
+    private Registry world;
+
+    /**
+     * Determine whether ontologies shall be persisted to registry when imported.
+     *
+     * @param doPersist Will import ontologies if true.
+     */
+    public void setDoPersist(final boolean doPersist) {
+        this.doPersist = doPersist;
+    }
+
+    /**
+     * Underlying ontology registry delegate.
+     *
+     * @param registry Ontology registry.
+     */
+    @Reference
+    public void setOntologyRegistry(final OntologyRegistry registry) {
+        this.delegate = registry;
+        setRegistryDelegate(registry);
+    }
+
+    /**
+     * Underlying ontology service.
+     *
+     * @param svc The ontology service.
+     */
+    @Reference
+    public void setOntologyService(final OntologyService svc) {
+        this.ontologyService = svc;
+    }
+
+    /**
+     * Underlying extension registry.
+     *
+     * @param registry The registry
+     */
+    @Reference
+    public void setExtensionRegistry(final ExtensionRegistry registry) {
+        this.extensionRegistry = registry;
+    }
+
+    /**
+     * Underlying general registry for resolving ontologies.
+     *
+     * @param registry The registry
+     */
+    @Reference(target = "(org.fcrepo.apix.registry.role=default)")
+    public void setGeneralRegistry(final Registry registry) {
+        this.world = registry;
+    }
+
+    @Override
+    public URI put(final WebResource ontology, final URI ontologyIRI) {
+        return delegate.put(ontology, ontologyIRI);
+    }
+
+    @Override
+    public WebResource get(final URI uri) {
+
+        if (doPersist && !delegate.contains(uri)) {
+            try (WebResource ontology = world.get(uri)) {
+                LOG.info("Persisting ontology <{}> as <{}>", ontology.uri(), uri);
+                delegate.put(ontology, uri);
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return delegate.get(uri);
+    }
+
+    @Override
+    public void update() {
+        extensionRegistry.list().forEach(this::update);
+    }
+
+    @Override
+    public void update(final URI inResponseTo) {
+        if (doPersist && extensionRegistry.hasInDomain(inResponseTo)) {
+            try (WebResource extension = extensionRegistry.get(inResponseTo)) {
+                LOG.debug("Loading ontologies from <{}>", inResponseTo);
+                ontologyService.parseOntology(extension);
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/fcrepo-api-x-jena/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-jena/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -26,6 +26,9 @@
       <cm:property name="registry.service.content"
         value="classpath:/objects/service-registry.ttl" />
       <cm:property name="registry.ontology.index" value="true" />
+      <cm:property name="registry.ontologies.persist" value="true" />
+      <cm:property name="registry.ontologies.binary" value="true" />
+      <cm:property name="registry.ontologies.cache" value="true" />
     </cm:default-properties>
   </cm:property-placeholder>
 
@@ -79,14 +82,23 @@
   </bean>
 
   <bean id="jenaOntologyServiceImpl" class="org.fcrepo.apix.jena.impl.JenaOntologyService">
-    <property name="registryDelegate" ref="jenaOntologyRegistryImpl" />
+    <property name="registryDelegate" ref="jenaPersistingOntologyRegistry" />
   </bean>
 
   <bean id="jenaOntologyRegistryImpl" class="org.fcrepo.apix.jena.impl.LookupOntologyRegistry"
     init-method="init" destroy-method="shutdown">
     <property name="registryDelegate" ref="ldpOntologyServiceRegistryDelegate" />
     <property name="indexIRIs" value="${registry.ontology.index}" />
+    <property name="persistAsBinary" value="${registry.ontologies.binary}" />
     <property name="initializer" ref="initMgr" />
+  </bean>
+
+  <bean id="jenaPersistingOntologyRegistry" class="org.fcrepo.apix.jena.impl.PersistingOntologyRegistry">
+    <property name="ontologyRegistry" ref="jenaOntologyRegistryImpl" />
+    <property name="extensionRegistry" ref="jenaExtensionRegistryImpl" />
+    <property name="ontologyService" ref="jenaOntologyServiceImpl" />
+    <property name="generalRegistry" ref="underlyingRegistryDelegate" />
+    <property name="doPersist" value="${registry.ontologies.persist}" />
   </bean>
 
   <bean id="jenaServiceRegistryImpl" class="org.fcrepo.apix.jena.impl.JenaServiceRegistry"
@@ -98,7 +110,7 @@
   </bean>
 
   <service id="jenaOntologyRegistry"
-    interface="org.fcrepo.apix.model.components.OntologyRegistry" ref="jenaOntologyRegistryImpl" />
+    interface="org.fcrepo.apix.model.components.OntologyRegistry" ref="jenaPersistingOntologyRegistry" />
 
   <service id="jenaOntologyService" interface="org.fcrepo.apix.model.components.OntologyService"
     ref="jenaOntologyServiceImpl" />
@@ -114,6 +126,9 @@
 
   <service id="jenaOntologyRegistryUpdater" interface="org.fcrepo.apix.model.components.Updateable"
     ref="jenaOntologyRegistryImpl" />
+
+  <service id="jenaPersistingOntologyRegistryUpdater" interface="org.fcrepo.apix.model.components.Updateable"
+    ref="jenaPersistingOntologyRegistry" />
 
   <service id="jenaInitializer" interface="org.fcrepo.apix.model.components.Initializer"
     ref="initMgr" />

--- a/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistryTest.java
+++ b/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/LookupOntologyRegistryTest.java
@@ -92,14 +92,15 @@ public class LookupOntologyRegistryTest {
         final URI ontologyIRI = URI.create("http://example.org/test#OntologyNoIRI");
 
         final WebResource ontologyToPersist = new ReadableResource(this.getClass().getResourceAsStream(
-                "/ontologyWithoutIRI.ttl"), "text/turtle", ontologyLocationURI, null);
+                "/ontologyWithoutIRI.ttl"), "text/turtle", null, null);
 
         final ArrayList<URI> entries = new ArrayList<>();
 
-        when(delegate.put(any(WebResource.class))).then(new Answer<URI>() {
+        when(delegate.put(any(WebResource.class), any(Boolean.class))).then(new Answer<URI>() {
 
             @Override
             public URI answer(final InvocationOnMock invocation) throws Throwable {
+
                 final WebResource submitted = ((WebResource) invocation.getArguments()[0]);
                 when(delegate.get(ontologyLocationURI)).thenReturn(submitted);
                 entries.add(ontologyLocationURI);

--- a/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/PersistingOntologyRegistryTest.java
+++ b/fcrepo-api-x-jena/src/test/java/org/fcrepo/apix/jena/impl/PersistingOntologyRegistryTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.jena.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.Arrays;
+
+import org.fcrepo.apix.model.WebResource;
+import org.fcrepo.apix.model.components.ExtensionRegistry;
+import org.fcrepo.apix.model.components.OntologyRegistry;
+import org.fcrepo.apix.model.components.OntologyService;
+import org.fcrepo.apix.model.components.Registry;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author apb@jhu.edu
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PersistingOntologyRegistryTest {
+
+    @Mock
+    Registry world;
+
+    @Mock
+    OntologyRegistry ontologyRegistry;
+
+    @Mock
+    ExtensionRegistry extensionRegistry;
+
+    @Mock
+    OntologyService ontologyService;
+
+    @Mock
+    WebResource resource;
+
+    final URI ontologyIRI = URI.create("http://example.org/ontologyIRI");
+
+    final URI extensionURI = URI.create("test:extension");
+
+    PersistingOntologyRegistry toTest = new PersistingOntologyRegistry();
+
+    @Before
+    public void setUp() {
+        toTest.setDoPersist(true);
+        toTest.setGeneralRegistry(world);
+        toTest.setOntologyRegistry(ontologyRegistry);
+        toTest.setOntologyService(ontologyService);
+        toTest.setExtensionRegistry(extensionRegistry);
+
+        when(world.get(ontologyIRI)).thenReturn(resource);
+        when(resource.uri()).thenReturn(URI.create("http://example.org/resource"));
+        when(ontologyRegistry.get(ontologyIRI)).thenReturn(resource);
+        when(extensionRegistry.hasInDomain(extensionURI)).thenReturn(true);
+        when(extensionRegistry.get(extensionURI)).thenReturn(resource);
+    }
+
+    @Test
+    public void ontologyNotInRegistryTest() {
+        when(ontologyRegistry.contains(ontologyIRI)).thenReturn(false);
+
+        assertEquals(resource, toTest.get(ontologyIRI));
+        verify(world).get(ontologyIRI);
+        verify(ontologyRegistry).put(any(WebResource.class), eq(ontologyIRI));
+    }
+
+    @Test
+    public void ontologyNotInRegistryButNoPeristTest() {
+        toTest.setDoPersist(false);
+
+        when(ontologyRegistry.contains(ontologyIRI)).thenReturn(false);
+
+        assertEquals(resource, toTest.get(ontologyIRI));
+        verifyZeroInteractions(world);
+        verify(ontologyRegistry, times(0)).put(any(WebResource.class), any(URI.class));
+    }
+
+    @Test
+    public void ontologyInRegistryTest() {
+        when(ontologyRegistry.contains(ontologyIRI)).thenReturn(true);
+
+        assertEquals(resource, toTest.get(ontologyIRI));
+        verifyZeroInteractions(world);
+        verify(ontologyRegistry, times(0)).put(any(WebResource.class), any(URI.class));
+    }
+
+    @Test
+    public void updateExtensionInDomainTest() {
+        toTest.update(extensionURI);
+
+        verify(ontologyService).parseOntology(eq(resource));
+    }
+
+    @Test
+    public void updateExtensionInDomainNotPersistingTest() {
+        toTest.setDoPersist(false);
+
+        toTest.update(extensionURI);
+
+        verifyZeroInteractions(extensionRegistry);
+        verifyZeroInteractions(ontologyRegistry);
+    }
+
+    @Test
+    public void updateExtensionNotInDomainTest() {
+        when(extensionRegistry.hasInDomain(extensionURI)).thenReturn(false);
+
+        toTest.update(extensionURI);
+
+        verifyZeroInteractions(ontologyRegistry);
+    }
+
+    @Test
+    public void updateTest() {
+        when(extensionRegistry.list()).thenReturn(Arrays.asList(extensionURI, extensionURI));
+
+        toTest.update();
+
+        verify(ontologyService, times(2)).parseOntology(eq(resource));
+    }
+
+    @Test
+    public void updateNoPersistTest() {
+        toTest.setDoPersist(false);
+        when(extensionRegistry.list()).thenReturn(Arrays.asList(extensionURI, extensionURI));
+
+        toTest.update();
+
+        verifyZeroInteractions(ontologyRegistry);
+    }
+}


### PR DESCRIPTION
Up until now, the only way for ontologies to be persisted to the ontology
registry was via manual intervention.  This adds an option to
automatically pesist any referenced ontology to the registry.

Resolves #91