### PR TITLE
Update indexing routes and osgi config

### DIFF
--- a/fcrepo-api-x-indexing/src/main/feature/feature.xml
+++ b/fcrepo-api-x-indexing/src/main/feature/feature.xml
@@ -7,8 +7,8 @@
   <feature name="fcrepo-api-x-indexing" description="fcrepo-api-x-indexing">
     version="${project.version}">
     <feature version="${camel.version}">camel-core</feature>
-    <feature version="${camel.version}">camel-jetty</feature>
-    <feature version="${fcrepo-camel.version}">fcrepo-camel</feature>
+    <feature version="${camel.version}">camel-http4</feature>
+    <feature version="${fcrepo-toolbox.version}">fcrepo-reindexing</feature>
     <feature version="${fcrepo-toolbox.version}">fcrepo-service-activemq</feature>
   </feature>
 </features>

--- a/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,8 +11,7 @@
        http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
 
   <cm:property-placeholder id="properties"
-    persistent-id="org.fcrepo.apix.indexing"
-    update-strategy="reload">
+    persistent-id="org.fcrepo.apix.indexing" update-strategy="reload">
 
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="10" />
@@ -21,7 +20,7 @@
       <cm:property name="service.reindex.stream" value="broker:queue:service.reindex" />
       <cm:property name="triplestore.baseUrl"
         value="http://localhost:8080/fuseki/test/update" />
-      <cm:property name="reindexing.service.uri" value="http://localhost:9090/reindexing" />
+      <cm:property name="reindexing.service.uri" value="http://localhost:9090/reindexing/" />
       <cm:property name="ldp.path.extension.container"
         value="/extensions" />
       <cm:property name="triplestore.namedGraph" value="" />
@@ -33,6 +32,8 @@
     <property name="extensionContainer" value="${ldp.path.extension.container}" />
     <property name="reindexStream" value="${service.reindex.stream}" />
   </bean>
+
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent" />
 
   <reference id="broker" interface="org.apache.camel.Component"
     filter="(osgi.jndi.service.name=fcrepo/Broker)" />

--- a/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,6 +34,7 @@
   </bean>
 
   <bean id="http" class="org.apache.camel.component.http4.HttpComponent" />
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent" />
 
   <reference id="broker" interface="org.apache.camel.Component"
     filter="(osgi.jndi.service.name=fcrepo/Broker)" />

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dexx-collection.version>0.6</dexx-collection.version>
     <fcrepo.version>4.7.0</fcrepo.version>
     <fcrepo-camel.version>4.4.4</fcrepo-camel.version>
-    <fcrepo-toolbox.version>4.6.1</fcrepo-toolbox.version>
+    <fcrepo-toolbox.version>4.6.2</fcrepo-toolbox.version>
     <fcrepo-build-tools.version>4.4.2</fcrepo-build-tools.version>
     <fcrepo.client.version>0.2.1</fcrepo.client.version>
     <httpclient.version>4.5.2</httpclient.version>


### PR DESCRIPTION
Indexing routes were not filtering messages property, and were assuming
the presence of the wrong headers in reindexing messages; Verified manually

Resolves #93