### PR TITLE
Update routing component to consider the request URI

### DIFF
--- a/fcrepo-api-x-indexing/src/main/java/org/fcrepo/apix/indexing/impl/ServiceIndexingRoutes.java
+++ b/fcrepo-api-x-indexing/src/main/java/org/fcrepo/apix/indexing/impl/ServiceIndexingRoutes.java
@@ -146,7 +146,7 @@ public class ServiceIndexingRoutes extends RouteBuilder {
 
                 // This is annoying, no easy way around
                 .doTry()
-                .to("{{apix.baseUrl}}")
+                .to("http://get-servicedoc-uri")
                 .doCatch(HttpOperationFailedException.class)
                 .to("direct:410")
                 .doFinally()
@@ -184,7 +184,7 @@ public class ServiceIndexingRoutes extends RouteBuilder {
                 .removeHeaders("CamelHttp*")
                 .setHeader(Exchange.HTTP_URI, bodyAs(URI.class))
                 .setBody(constant(null))
-                .to("http://localhost")
+                .to("http://perform-index")
                 .setHeader(FCREPO_NAMED_GRAPH, header(Exchange.HTTP_URI))
                 .removeHeaders("CamelHttp*")
                 .process(SPARQL_UPDATE_PROCESSOR)

--- a/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-indexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,8 +15,6 @@
 
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="10" />
-      <cm:property name="apix.baseUrl"
-        value="http://localhost:8080/fcrepo/rest?throwExceptionOnFailure=false" />
       <cm:property name="service.index.stream" value="broker:topic:fedora" />
       <cm:property name="service.reindex.stream" value="broker:queue:service.reindex" />
       <cm:property name="triplestore.baseUrl"

--- a/fcrepo-api-x-indexing/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
+++ b/fcrepo-api-x-indexing/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
@@ -15,8 +15,6 @@
 
     <cm:default-properties>
       <cm:property name="error.maxRedeliveries" value="10" />
-      <cm:property name="apix.baseUrl"
-        value="http://localhost:8080/fcrepo/rest?throwExceptionOnFailure=false" />
       <cm:property name="service.index.stream" value="broker:topic:fedora" />
       <cm:property name="service.reindex.stream" value="broker:queue:service.reindex" />
       <cm:property name="triplestore.baseUrl"

--- a/fcrepo-api-x-integration/pom.xml
+++ b/fcrepo-api-x-integration/pom.xml
@@ -70,6 +70,13 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reserve-port</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
         <configuration>
           <portNames>
             <portName>apix.dynamic.test.port</portName>
@@ -81,13 +88,6 @@
             <portName>reindexing.dynamic.test.port</portName>
           </portNames>
         </configuration>
-        <executions>
-          <execution>
-            <id>reserve-port</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ExposedServiceIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ExposedServiceIT.java
@@ -43,6 +43,7 @@ import javax.inject.Inject;
 
 import org.fcrepo.apix.model.WebResource;
 import org.fcrepo.apix.model.components.ExtensionRegistry;
+import org.fcrepo.apix.model.components.RoutingFactory;
 import org.fcrepo.apix.model.components.ServiceDiscovery;
 import org.fcrepo.apix.model.components.ServiceRegistry;
 import org.fcrepo.apix.model.components.Updateable;
@@ -79,6 +80,8 @@ public class ExposedServiceIT implements KarafIT {
     final String serviceEndpoint = "http://127.0.0.1:" + System.getProperty("services.dynamic.test.port") +
             "/ExposedServiceIT";
 
+    URI requestURI = URI.create(apixBaseURI);
+
     URI exposedServiceEndpoint;
 
     private final Message responseFromService = new DefaultMessage();
@@ -100,6 +103,9 @@ public class ExposedServiceIT implements KarafIT {
 
     @Inject
     BundleContext bundleContext;
+
+    @Inject
+    RoutingFactory routingFactory;
 
     @Override
     public String testClassName() {
@@ -254,7 +260,8 @@ public class ExposedServiceIT implements KarafIT {
                 .forEach(Updateable::update);
 
         // Look at the service document to discover the exposed URI
-        try (WebResource resource = discovery.getServiceDocumentFor(object, "text/turtle")) {
+        try (WebResource resource = discovery
+                .getServiceDocumentFor(object, routingFactory.of(requestURI), "text/turtle")) {
             final Model doc = parse(resource);
 
             final String sparql = "CONSTRUCT { ?endpoint <test:/endpointFor> ?serviceInstance . } WHERE { " +
@@ -286,7 +293,8 @@ public class ExposedServiceIT implements KarafIT {
                 .forEach(Updateable::update);
 
         // Look at the service document to discover the exposed URI
-        try (WebResource resource = discovery.getServiceDocumentFor(object, "text/turtle")) {
+        try (WebResource resource = discovery
+                .getServiceDocumentFor(object, routingFactory.of(requestURI), "text/turtle")) {
             final Model doc = parse(resource);
 
             final String sparql = "CONSTRUCT { ?endpoint <test:/endpointFor> ?serviceInstance . } WHERE { " +
@@ -310,7 +318,8 @@ public class ExposedServiceIT implements KarafIT {
                 .forEach(Updateable::update);
 
         // Look at the service document to discover the exposed URI
-        try (WebResource resource = discovery.getServiceDocumentFor(object, "text/turtle")) {
+        try (WebResource resource = discovery
+                .getServiceDocumentFor(object, routingFactory.of(requestURI), "text/turtle")) {
             final Model doc = parse(resource);
 
             final String sparql = "CONSTRUCT { ?endpoint <test:/endpointFor> ?serviceInstance . } WHERE { " +

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/InterceptingModalityIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/InterceptingModalityIT.java
@@ -29,7 +29,7 @@ import java.net.URI;
 
 import javax.inject.Inject;
 
-import org.fcrepo.apix.model.components.Routing;
+import org.fcrepo.apix.model.components.RoutingFactory;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
@@ -51,8 +51,10 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
 
     final String TEST_OBJECT_TYPE = "test:InterceptingModalityIT#object";
 
+    final URI REQUEST_URI = URI.create(apixBaseURI);
+
     @Inject
-    Routing routing;
+    RoutingFactory routing;
 
     @Rule
     public TestName name = new TestName();
@@ -78,10 +80,12 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
 
         final URI object = client.post(objectContainer).slug(testMethodName()).perform().getLocation();
 
-        final FcrepoResponse response = client.get(routing.interceptUriFor(object)).perform();
+        final FcrepoResponse response = client.get(
+                routing.of(REQUEST_URI).interceptUriFor(object)).perform();
 
         assertEquals(1, response.getLinkHeaders("service").size());
-        assertEquals(routing.serviceDocFor(object), response.getLinkHeaders("service").get(0));
+        assertEquals(routing.of(REQUEST_URI).serviceDocFor(object),
+                response.getLinkHeaders("service").get(0));
     }
 
     // Verify that if an intercepting extension throws a 4xx code, it aborts the request and returns service response.
@@ -97,7 +101,7 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
         responseFromService.setHeader(Exchange.HTTP_RESPONSE_CODE, RESPONSE_CODE);
         responseFromService.setHeader("Location", LOCATION);
 
-        final URI objectContainer_intercept = routing.interceptUriFor(objectContainer);
+        final URI objectContainer_intercept = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         final URI object = postFromTestResource("objects/object_InterceptingServiceIT.ttl",
                 objectContainer_intercept);
@@ -113,7 +117,7 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
         registerExtension(testResource("objects/extension_InterceptingModalityIT.ttl"));
         registerService(testResource("objects/service_InterceptingServiceIT.ttl"));
 
-        final URI objectContainer_intercept = routing.interceptUriFor(objectContainer);
+        final URI objectContainer_intercept = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         // Have our extension service set an implausible If-Match header for the request
         onServiceRequest(ex -> {
@@ -138,7 +142,7 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
         registerExtension(testResource("objects/extension_InterceptingModalityIT.ttl"));
         registerService(testResource("objects/service_InterceptingServiceIT.ttl"));
 
-        final URI objectContainer_intercept = routing.interceptUriFor(objectContainer);
+        final URI objectContainer_intercept = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         // Have our extension service set an implausible If-Match header for the request
         onServiceRequest(ex -> {
@@ -164,7 +168,7 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
         registerExtension(testResource("objects/extension_InterceptingModalityIT.ttl"));
         registerService(testResource("objects/service_InterceptingServiceIT.ttl"));
 
-        final URI objectContainer_intercept = routing.interceptUriFor(objectContainer);
+        final URI objectContainer_intercept = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         final String TYPE = "test:" + name.getMethodName();
 
@@ -194,7 +198,7 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
         registerExtension(testResource("objects/extension_InterceptingModalityIT.ttl"));
         registerService(testResource("objects/service_InterceptingServiceIT.ttl"));
 
-        final URI objectContainer_intercept = routing.interceptUriFor(objectContainer);
+        final URI objectContainer_intercept = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
         final String TEST_HEADER = "testHeader";
         final String TEST_HEADER_VALUE = "testHeaderValue";
 
@@ -220,7 +224,7 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
         registerExtension(testResource("objects/extension_InterceptingModalityIT.ttl"));
         registerService(testResource("objects/service_InterceptingServiceIT.ttl"));
 
-        final URI objectContainer_intercept = routing.interceptUriFor(objectContainer);
+        final URI objectContainer_intercept = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         final String BODY = "theBody";
 
@@ -245,7 +249,7 @@ public class InterceptingModalityIT extends ServiceBasedTest implements KarafIT 
         registerExtension(testResource("objects/extension_InterceptingModalityIT.ttl"));
         registerService(testResource("objects/service_InterceptingServiceIT.ttl"));
 
-        final URI objectContainer_intercept = routing.interceptUriFor(objectContainer);
+        final URI objectContainer_intercept = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         // Give our request a specific body
         onServiceRequest(ex -> {

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafServiceIndexingIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/KarafServiceIndexingIT.java
@@ -41,7 +41,7 @@ import javax.inject.Inject;
 
 import org.fcrepo.apix.model.Extension;
 import org.fcrepo.apix.model.Extension.Scope;
-import org.fcrepo.apix.model.components.Routing;
+import org.fcrepo.apix.model.components.RoutingFactory;
 import org.fcrepo.client.FcrepoResponse;
 
 import org.apache.camel.CamelContext;
@@ -75,11 +75,13 @@ public class KarafServiceIndexingIT extends ServiceBasedTest {
 
     static final AtomicInteger objectCounter = new AtomicInteger(0);
 
+    static final URI requestURI = URI.create(apixBaseURI);
+
     @Rule
     public TestName name = new TestName();
 
     @Inject
-    public Routing routing;
+    public RoutingFactory routing;
 
     @Inject
     @Filter("(role=FcrepoServiceIndexer)")
@@ -160,7 +162,7 @@ public class KarafServiceIndexingIT extends ServiceBasedTest {
         final Extension extension = newExtension(name).withScope(Scope.RESOURCE).create();
 
         // Just post an empty object
-        final URI object = client.post(routing.interceptUriFor(objectContainer)).perform().getUrl();
+        final URI object = client.post(routing.of(requestURI).interceptUriFor(objectContainer)).perform().getUrl();
 
         // Make sure the extension is not in service doc.
         attempt(60, () -> assertSparqlNotBound(object, extension));
@@ -186,7 +188,7 @@ public class KarafServiceIndexingIT extends ServiceBasedTest {
 
     URI createObjectMatching(final Extension extension) throws Exception {
 
-        try (FcrepoResponse response = client.post(routing.interceptUriFor(objectContainer))
+        try (FcrepoResponse response = client.post(routing.of(requestURI).interceptUriFor(objectContainer))
                 .body(IOUtils.toInputStream(
                         String.format("<> a <%s> .", extension.bindingClass()), "utf8"),
                         "text/turtle").slug(objectName()).perform()) {

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/LoaderIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/LoaderIT.java
@@ -50,7 +50,7 @@ import javax.inject.Inject;
 import org.fcrepo.apix.model.Service;
 import org.fcrepo.apix.model.WebResource;
 import org.fcrepo.apix.model.components.Registry;
-import org.fcrepo.apix.model.components.Routing;
+import org.fcrepo.apix.model.components.RoutingFactory;
 import org.fcrepo.apix.model.components.ServiceRegistry;
 import org.fcrepo.client.FcrepoResponse;
 
@@ -89,6 +89,8 @@ public class LoaderIT extends ServiceBasedTest {
 
     final URI SERVICE_ONT = URI.create("http://example.org/LoaderIT/ont");
 
+    final URI REQUEST_URI = URI.create(apixBaseURI);
+
     final AtomicReference<Object> optionsResponse = new AtomicReference<>();
 
     final AtomicReference<Object> serviceResponse = new AtomicReference<>();
@@ -114,7 +116,7 @@ public class LoaderIT extends ServiceBasedTest {
     }
 
     @Inject
-    Routing routing;
+    RoutingFactory routing;
 
     @BeforeClass
     public static void init() throws Exception {
@@ -179,7 +181,7 @@ public class LoaderIT extends ServiceBasedTest {
         // Verify that extension works!
 
         // Get the intercept/proxy URI for a fedora container
-        final URI container = routing.interceptUriFor(objectContainer);
+        final URI container = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         // Deposit an object into the container
         final URI deposited = client.post(container).slug("LoaderIT_htmlMinimalTest")
@@ -211,7 +213,7 @@ public class LoaderIT extends ServiceBasedTest {
         // Verify that extension works!
 
         // Get the intercept/proxy URI for a fedora container
-        final URI container = routing.interceptUriFor(objectContainer);
+        final URI container = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         // Deposit an object into the container
         final URI deposited = client.post(container).slug("LoaderIT_definedServiceTest")
@@ -246,7 +248,7 @@ public class LoaderIT extends ServiceBasedTest {
         // Verify that extension works!
 
         // Get the intercept/proxy URI for a fedora container
-        final URI container = routing.interceptUriFor(objectContainer);
+        final URI container = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         // Deposit an object into the container, as a text/plain binary
         final URI deposited = client.post(container).slug("LoaderIT_" + name.getMethodName())

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceDocumentIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceDocumentIT.java
@@ -33,9 +33,9 @@ import javax.inject.Inject;
 import org.fcrepo.apix.model.WebResource;
 import org.fcrepo.apix.model.components.ExtensionRegistry;
 import org.fcrepo.apix.model.components.Registry;
-import org.fcrepo.apix.model.components.Routing;
 
 import org.apache.jena.rdf.model.Model;
+import org.fcrepo.apix.model.components.RoutingFactory;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,6 +50,8 @@ import org.ops4j.pax.exam.util.Filter;
 @RunWith(PaxExam.class)
 public class ServiceDocumentIT implements KarafIT {
 
+    private static final URI REQUEST_URI = URI.create(apixBaseURI);
+
     @Inject
     @Filter("(org.fcrepo.apix.registry.role=default)")
     Registry repository;
@@ -58,7 +60,7 @@ public class ServiceDocumentIT implements KarafIT {
     ExtensionRegistry extensionRegistry;
 
     @Inject
-    Routing routing;
+    RoutingFactory routing;
 
     @Rule
     public TestName name = new TestName();
@@ -82,7 +84,7 @@ public class ServiceDocumentIT implements KarafIT {
     @Test
     public void emptyServiceDocumentTest() throws Exception {
 
-        final URI object = routing.interceptUriFor(serviceContainer);
+        final URI object = routing.of(REQUEST_URI).interceptUriFor(serviceContainer);
         final URI serviceDocURI = client.head(object).perform().getLinkHeaders("service").get(0);
 
         try (WebResource resource = repository.get(serviceDocURI)) {
@@ -104,7 +106,7 @@ public class ServiceDocumentIT implements KarafIT {
         extensionRegistry.put(testResource(
                 "objects/extension_serviceDocumentIT.ttl"));
 
-        final URI container = routing.interceptUriFor(objectContainer);
+        final URI container = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
         final URI object = postFromTestResource("objects/object_serviceDocumentIT.ttl", container);
 

--- a/fcrepo-api-x-listener/src/main/java/org/fcrepo/apix/listener/impl/UpdateListener.java
+++ b/fcrepo-api-x-listener/src/main/java/org/fcrepo/apix/listener/impl/UpdateListener.java
@@ -25,8 +25,9 @@ import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import java.net.URI;
 import java.util.List;
 
-import org.fcrepo.apix.model.components.Routing;
+import org.fcrepo.apix.model.components.RoutingFactory;
 import org.fcrepo.apix.model.components.Updateable;
+import org.fcrepo.camel.FcrepoHeaders;
 import org.fcrepo.camel.processor.EventProcessor;
 
 import org.apache.camel.Processor;
@@ -47,7 +48,7 @@ public class UpdateListener extends RouteBuilder {
 
     private static final String TYPE_REPOSITORY_RESOURCE = "http://fedora.info/definitions/v4/repository#Resource";
 
-    private Routing routing;
+    private RoutingFactory routing;
 
     /**
      * Set the list of services to update
@@ -63,7 +64,7 @@ public class UpdateListener extends RouteBuilder {
      *
      * @param routing Routing impl.
      */
-    public void setRouting(final Routing routing) {
+    public void setRouting(final RoutingFactory routing) {
         this.routing = routing;
     }
 
@@ -88,7 +89,7 @@ public class UpdateListener extends RouteBuilder {
     }
 
     private final Processor USE_FCREPO_URIS = ex -> {
-        ex.getIn().setHeader(FCREPO_URI,
-                routing.nonProxyURIFor(URI.create(ex.getIn().getHeader(FCREPO_URI, String.class))));
+        final URI fcrepoUri = URI.create(ex.getIn().getHeader(FcrepoHeaders.FCREPO_URI, String.class));
+        ex.getIn().setHeader(FcrepoHeaders.FCREPO_URI, routing.of(fcrepoUri).nonProxyURIFor(fcrepoUri));
     };
 }

--- a/fcrepo-api-x-listener/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-listener/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,7 +20,7 @@
   <reference id="broker" interface="org.apache.camel.Component"
     filter="(osgi.jndi.service.name=fcrepo/Broker)" />
 
-  <reference id="routing" interface="org.fcrepo.apix.model.components.Routing" />
+  <reference id="routing" interface="org.fcrepo.apix.model.components.RoutingFactory" />
 
   <reference-list id="toUpdate" member-type="service-object"
     interface="org.fcrepo.apix.model.components.Updateable"

--- a/fcrepo-api-x-loader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-loader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -31,7 +31,7 @@
   <reference id="generalRegistry" filter="(org.fcrepo.apix.registry.role=default)"
     interface="org.fcrepo.apix.model.components.Registry" />
 
-  <reference id="routing" interface="org.fcrepo.apix.model.components.Routing" />
+  <reference id="routing" interface="org.fcrepo.apix.model.components.RoutingFactory" />
 
   <bean id="loaderService" class="org.fcrepo.apix.loader.impl.LoaderService">
     <property name="extensionRegistry" ref="extensionRegistry" />

--- a/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/RoutingFactory.java
+++ b/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/RoutingFactory.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Johns Hopkins University
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/RoutingFactory.java
+++ b/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/RoutingFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.apix.model.components;
+
+import java.net.URI;
+
+/**
+ * Produces {@link Routing} instances for requested resources.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public interface RoutingFactory {
+
+    /**
+     * Answers a {@link Routing} for the requested resource.
+     *
+     * @param requestUri the URI of the requested resource
+     * @return the {@code Routing}
+     */
+    Routing of(URI requestUri);
+
+}

--- a/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/ServiceDiscovery.java
+++ b/fcrepo-api-x-model/src/main/java/org/fcrepo/apix/model/components/ServiceDiscovery.java
@@ -33,9 +33,10 @@ public interface ServiceDiscovery {
      * Produce a service document for the given resource
      *
      * @param resource A repository resource URI
+     * @param routing the {@code Routing} for the repository {@code resource}
      * @param contentType Desired media types, or null if any serialization is acceptable.
      * @return Serialized service document
      */
-    WebResource getServiceDocumentFor(URI resource, String... contentType);
+    WebResource getServiceDocumentFor(URI resource, Routing routing, String... contentType);
 
 }

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzer.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzer.java
@@ -35,7 +35,7 @@ import org.fcrepo.apix.model.components.ExtensionRegistry;
 import org.fcrepo.apix.model.components.Initializer;
 import org.fcrepo.apix.model.components.Initializer.Initialization;
 import org.fcrepo.apix.model.components.ResourceNotFoundException;
-import org.fcrepo.apix.model.components.Routing;
+import org.fcrepo.apix.model.components.RoutingFactory;
 import org.fcrepo.apix.model.components.Updateable;
 
 import org.slf4j.Logger;
@@ -53,7 +53,7 @@ public class ExposedServiceUriAnalyzer implements Updateable {
 
     private ExtensionRegistry extensions;
 
-    private Routing routing;
+    private RoutingFactory routing;
 
     private String exposePath;
 
@@ -99,7 +99,7 @@ public class ExposedServiceUriAnalyzer implements Updateable {
      *
      * @param routing The routing component
      */
-    public void setRouting(final Routing routing) {
+    public void setRouting(final RoutingFactory routing) {
         this.routing = routing;
     }
 
@@ -207,7 +207,7 @@ public class ExposedServiceUriAnalyzer implements Updateable {
                     ? rawPath.substring(0, rawPath.indexOf(exposeSegment) - 1)
                     : null;
 
-            final URI exposedServiceURI = routing.endpointFor(extension.exposed(), resourcePath);
+            final URI exposedServiceURI = routing.of(requestURI).endpointFor(extension.exposed(), resourcePath);
 
             return new ServiceExposingBinding(
                     extension,

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ImmutableRouter.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ImmutableRouter.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Johns Hopkins University
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ImmutableRouter.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/ImmutableRouter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.apix.routing.impl;
+
+import java.net.URI;
+
+/**
+ * Immutable version of {@code RoutingStub}; throws {@link UnsupportedOperationException} for mutating methods.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+class ImmutableRouter extends RoutingStub {
+
+    ImmutableRouter(final String scheme, final String host, final int port, final RoutingPrototype delegate) {
+        super.setScheme(scheme);
+        super.setHost(host);
+        super.setPort(port);
+        super.setDiscoveryPath(delegate.getDiscoveryPath());
+        super.setExposePath(delegate.getExposePath());
+        super.setInterceptPath(delegate.getInterceptPath());
+        super.setFcrepoBaseURI(delegate.getFcrepoBaseURI());
+    }
+
+    @Override
+    public void setScheme(final String scheme) {
+        throw new UnsupportedOperationException("Instance is immutable.");
+    }
+
+    @Override
+    public void setHost(final String host) {
+        throw new UnsupportedOperationException("Instance is immutable.");
+    }
+
+    @Override
+    public void setPort(final int port) {
+        throw new UnsupportedOperationException("Instance is immutable.");
+    }
+
+    @Override
+    public void setDiscoveryPath(final String path) {
+        throw new UnsupportedOperationException("Instance is immutable.");
+    }
+
+    @Override
+    public void setInterceptPath(final String path) {
+        throw new UnsupportedOperationException("Instance is immutable.");
+    }
+
+    @Override
+    public void setFcrepoBaseURI(final URI uri) {
+        throw new UnsupportedOperationException("Instance is immutable.");
+    }
+
+    @Override
+    public void setExposePath(final String path) {
+        throw new UnsupportedOperationException("Instance is immutable.");
+    }
+
+}

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingPrototype.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingPrototype.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Johns Hopkins University
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingPrototype.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingPrototype.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2017 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.apix.routing.impl;
+
+import org.fcrepo.apix.model.Extension;
+import org.fcrepo.apix.model.components.ResourceNotFoundException;
+import org.fcrepo.apix.model.components.Routing;
+import org.fcrepo.apix.model.components.RoutingFactory;
+
+import java.net.URI;
+
+import static org.fcrepo.apix.routing.Util.append;
+
+/**
+ * A prototype holding common {@code Routing} configuration parameters for concrete implementations.
+ *
+ * @author Elliot Metsger (emetsger@jhu.edu)
+ */
+public abstract class RoutingPrototype implements RoutingFactory, Routing {
+
+    private String discoveryPath;
+
+    private String exposePath;
+
+    private String interceptPath;
+
+    private URI fcrepoBaseURI;
+
+    /**
+     * Set the API-X service path.
+     * <p>
+     * Used for providing access to service document resources, as in
+     * <code>http://${apix.host}:${apix.port}/${apix.svcPath}/path/to/object</code>
+     * </p>
+     *
+     * @param path The path segment.
+     */
+    public void setDiscoveryPath(final String path) {
+        this.discoveryPath = path;
+    }
+
+    /**
+     * Set the intercept path segment
+     *
+     * @param path intercept path segment
+     */
+    public void setInterceptPath(final String path) {
+        this.interceptPath = path;
+    }
+
+    /**
+     * Set Fedora's baseURI.
+     *
+     * @param uri the base URI.
+     */
+    public void setFcrepoBaseURI(final URI uri) {
+        this.fcrepoBaseURI = uri;
+    }
+
+    /**
+     * Set the API-X Service Exposure path.
+     * <p>
+     * This establishes a baseURI for exposed services;
+     * <code>http://${apix.host}:${apix.port}/${apix.svcPath}/path/to/object/${exposedAt}</code>
+     * </p>
+     *
+     * @param path The path segment.
+     */
+    public void setExposePath(final String path) {
+        this.exposePath = path;
+    }
+
+    /**
+     * Set the API-X service path.
+     * <p>
+     * Used for providing access to service document resources, as in
+     * <code>http://${apix.host}:${apix.port}/${apix.svcPath}/path/to/object</code>
+     * </p>
+     *
+     * @return The path segment.
+     */
+    public String getDiscoveryPath() {
+        return discoveryPath;
+    }
+
+    /**
+     * Set the API-X Service Exposure path.
+     * <p>
+     * This establishes a baseURI for exposed services;
+     * <code>http://${apix.host}:${apix.port}/${apix.svcPath}/path/to/object/${exposedAt}</code>
+     * </p>
+     *
+     * @return The path segment.
+     */
+    public String getExposePath() {
+        return exposePath;
+    }
+
+    /**
+     * Set the intercept path segment
+     *
+     * @return intercept path segment
+     */
+    public String getInterceptPath() {
+        return interceptPath;
+    }
+
+    /**
+     * Set Fedora's baseURI.
+     *
+     * @return the base URI.
+     */
+    public URI getFcrepoBaseURI() {
+        return fcrepoBaseURI;
+    }
+
+    @Override
+    public URI endpointFor(final Extension.ServiceExposureSpec spec, final String path) {
+        switch (spec.scope()) {
+            case EXTERNAL:
+                return spec.exposedAt();
+            case REPOSITORY:
+                return append(exposedBaseURI(), exposePath, "", spec.exposedAt().getPath());
+            case RESOURCE:
+                return append(exposedBaseURI(), exposePath, path, spec.exposedAt());
+            default:
+                throw new RuntimeException("Unknown service exposure scope " + spec.scope());
+        }
+    }
+
+    @Override
+    public URI endpointFor(final Extension.ServiceExposureSpec spec, final URI onResource) {
+        return endpointFor(spec, resourcePath(onResource));
+    }
+
+    @Override
+    public URI serviceDocFor(final URI resource) {
+        return serviceDocFor(resourcePath(resource));
+    }
+
+    @Override
+    public URI serviceDocFor(final String resourcePath) {
+        return append(exposedBaseURI(), discoveryPath, resourcePath);
+    }
+
+    @Override
+    public String resourcePath(final URI resourceURI) {
+
+        final String r = resourceURI.toString();
+
+        if (r.startsWith(fcrepoBaseURI.toString())) {
+            return "/" + fcrepoBaseURI.relativize(resourceURI).getPath();
+        }
+
+        final URI interceptBase = append(exposedBaseURI(), interceptPath);
+
+        if (r.startsWith(interceptBase.toString())) {
+            return "/" + interceptBase.relativize(resourceURI).getPath();
+        } else {
+            throw new ResourceNotFoundException(String.format(
+                    "%s is not in the repository or intercept domain (%s, %s)", r, fcrepoBaseURI, interceptBase));
+        }
+
+    }
+
+    @Override
+    public URI interceptUriFor(final URI resource) {
+        if (resource.getPath().startsWith(interceptPath.toString())) {
+            return resource;
+        }
+        return append(exposedBaseURI(), interceptPath, resourcePath(resource));
+    }
+
+    @Override
+    public URI nonProxyURIFor(final URI resource) {
+        if (resource.getPath().startsWith(fcrepoBaseURI.toString())) {
+            return resource;
+        }
+        return append(fcrepoBaseURI, resourcePath(resource));
+    }
+
+    /**
+     * Implementation note: the returned {@code Routing} implementation is immutable; invoking any setters will result
+     * in an {@code UnsupportedOperationException} being thrown.
+     * <p>
+     * {@inheritDoc}
+     * </p>
+     *
+     * @param requestUri {@inheritDoc}
+     * @return answers an <em>immutable</em> {@code Routing} implementation
+     */
+    @Override
+    public Routing of(final URI requestUri) {
+        if (requestUri == null) {
+            throw new NullPointerException("Request URI must not be null!");
+        }
+        return new ImmutableRouter(requestUri.getScheme(),
+                requestUri.getHost(),
+                (requestUri.getPort() < 0) ? 80 : requestUri.getPort(),
+                this);
+    }
+
+    /**
+     * Implementations are expected to provide the base URI for HTTP resources publicly exposed by API-X.  Typically
+     * this will be derived from the HTTP request received by API-X from the user-agent.  This base URI will be used to
+     * construct URIs in responses to the client.
+     * <p>
+     * If a request is received by API-X at http://example.org/fcrepo/rest/foo, then the exposed base URI would be
+     * {@code http://example.org/}.  If a request is received by API-X at http://example.org:8080/fcrepo/rest/foo, then
+     * the exposed base URI would be {@code http://example.org:8080/}.  Implementations are free to use the HTTP
+     * {@code Host} header or any other means to determine the publicly-facing API-X base URI.
+     * </p>
+     *
+     * @return the publicly-facing base URI of resources exposed by API-X.
+     */
+    abstract URI exposedBaseURI();
+
+}

--- a/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-routing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -13,9 +13,8 @@
   <cm:property-placeholder persistent-id="org.fcrepo.apix.routing"
     update-strategy="reload">
     <cm:default-properties>
-      <cm:property name="apix.host" value="localhost" />
-      <cm:property name="apix.port" value="8081" />
       <cm:property name="apix.listen.host" value="0.0.0.0" />
+      <cm:property name="apix.port" value="8081" />
       <cm:property name="apix.discoveryPath" value="discovery" />
       <cm:property name="apix.exposePath" value="services" />
       <cm:property name="apix.interceptPath" value="fcrepo/rest" />
@@ -42,8 +41,6 @@
   <bean id="https" class="org.apache.camel.component.http4.HttpComponent" />
 
   <bean id="routingStub" class="org.fcrepo.apix.routing.impl.RoutingStub">
-    <property name="host" value="${apix.host}" />
-    <property name="port" value="${apix.port}" />
     <property name="discoveryPath" value="${apix.discoveryPath}" />
     <property name="exposePath" value="${apix.exposePath}" />
     <property name="interceptPath" value="${apix.interceptPath}" />
@@ -80,10 +77,9 @@
     <property name="extensionBinding" ref="extensionBinding" />
     <property name="relativeURIs" value="${discovery.relativeURIs}" />
     <property name="interceptURIs" value="${discovery.interceptURIs}" />
-    <property name="routing" ref="routingStub" />
   </bean>
 
-  <service id="routing" interface="org.fcrepo.apix.model.components.Routing"
+  <service id="routingFactory" interface="org.fcrepo.apix.model.components.RoutingFactory"
     ref="routingStub" />
 
   <service id="serviceDiscovery"

--- a/fcrepo-api-x-routing/src/test/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzerTest.java
+++ b/fcrepo-api-x-routing/src/test/java/org/fcrepo/apix/routing/impl/ExposedServiceUriAnalyzerTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
@@ -38,6 +39,7 @@ import org.fcrepo.apix.model.Extension.Scope;
 import org.fcrepo.apix.model.Extension.ServiceExposureSpec;
 import org.fcrepo.apix.model.components.ExtensionRegistry;
 import org.fcrepo.apix.model.components.Routing;
+import org.fcrepo.apix.model.components.RoutingFactory;
 import org.fcrepo.apix.routing.impl.ExposedServiceUriAnalyzer.ServiceExposingBinding;
 
 import org.junit.Before;
@@ -53,7 +55,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class ExposedServiceUriAnalyzerTest {
 
     @Mock
-    Routing routing;
+    RoutingFactory routing;
 
     @Mock
     ExtensionRegistry extensisons;
@@ -102,7 +104,9 @@ public class ExposedServiceUriAnalyzerTest {
         when(extension1Spec.exposedAt()).thenReturn(extension1ExposedAt);
         when(extension1Spec.scope()).thenReturn(Scope.RESOURCE);
 
-        when(routing.endpointFor(any(ServiceExposureSpec.class), any(String.class))).thenAnswer(i -> {
+        when(routing.of(any())).thenReturn(mock(Routing.class));
+
+        when(routing.of(any()).endpointFor(any(ServiceExposureSpec.class), any(String.class))).thenAnswer(i -> {
             final ServiceExposureSpec spec = i.getArgumentAt(0, ServiceExposureSpec.class);
             final String path = i.getArgumentAt(1, String.class);
 

--- a/fcrepo-api-x-routing/src/test/java/org/fcrepo/apix/routing/impl/RoutingStubTest.java
+++ b/fcrepo-api-x-routing/src/test/java/org/fcrepo/apix/routing/impl/RoutingStubTest.java
@@ -34,6 +34,7 @@ public class RoutingStubTest {
 
     @Before
     public void setUp() {
+        toTest.setScheme("http");
         toTest.setHost("www.example.org");
         toTest.setPort(8080);
         toTest.setInterceptPath("/intercept/path");
@@ -48,10 +49,10 @@ public class RoutingStubTest {
     public void testBaseUriPortPresence() {
 
         toTest.setPort(80);
-        assertEquals("http://www.example.org/", toTest.baseURI().toString());
+        assertEquals("http://www.example.org/", toTest.exposedBaseURI().toString());
 
         toTest.setPort(8080);
-        assertEquals("http://www.example.org:8080/", toTest.baseURI().toString());
+        assertEquals("http://www.example.org:8080/", toTest.exposedBaseURI().toString());
     }
 
     @Test


### PR DESCRIPTION
Addresses https://github.com/fcrepo4-labs/fcrepo-api-x-demo/issues/35

- introduces RoutingFactory for creating Routing instances
- introduces ImmutableRouting as an immutable implementation of Router
- updates ServiceIndexingRoutesTest to provide route advice prior to the starting of the Camel context
- updated build-helper-maven-plugin configuration so it only reserves ports once in the lifecycle
- updates tests and ITs
- removes apix.host property from routing component and apix.baseUrl property from indexing