### PR TITLE
Allow ConfigurationAdmin to be undefined

### DIFF
--- a/fcrepo-api-x-indexing/src/main/feature/feature.xml
+++ b/fcrepo-api-x-indexing/src/main/feature/feature.xml
@@ -9,5 +9,6 @@
     <feature version="${camel.version}">camel-http4</feature>
     <feature version="${fcrepo-toolbox.version}">fcrepo-reindexing</feature>
     <feature version="${fcrepo-toolbox.version}">fcrepo-service-activemq</feature>
+    <feature version="${project.version}">fcrepo-api-x-registry</feature>
   </feature>
 </features>

--- a/fcrepo-api-x-registry/pom.xml
+++ b/fcrepo-api-x-registry/pom.xml
@@ -35,17 +35,22 @@
       <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+      <version>1.5.0</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-osgi</artifactId>
-      <version>${httpcore.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
-      <version>${httpclient.version}</version>
     </dependency>
 
     <dependency>

--- a/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/ConfigHelper.java
+++ b/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/ConfigHelper.java
@@ -47,7 +47,7 @@ public class ConfigHelper {
     /**
      * Get properties as a map.
      * <p>
-     * Returns an empty map if ConfigurationAdmin is null, or the configuration is null, etc.
+     * Returns an empty map if configAdmin is null, or the configuration is null, etc.
      * </p>
      *
      * @param pid OSGI configAdmin pid.

--- a/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/ConfigHelper.java
+++ b/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/ConfigHelper.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.apix.registry;
+
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * Helps get properties from OSGi ConfigurationAdmin.
+ *
+ * @author apb@jhu.edu
+ */
+public class ConfigHelper {
+
+    private ConfigurationAdmin configAdmin;
+
+    /**
+     * Set the OSGi configurationAdmin.
+     *
+     * @param config configuration.
+     */
+    public void setConfigurationAdmin(final ConfigurationAdmin config) {
+        this.configAdmin = config;
+    }
+
+    /**
+     * Get properties as a map.
+     * <p>
+     * Returns an empty map if ConfigurationAdmin is null, or the configuration is null, etc.
+     * </p>
+     *
+     * @param pid OSGI configAdmin pid.
+     * @return map of properties
+     */
+    public Map<String, String> getProperties(final String pid) throws Exception {
+        final Map<String, String> props = new HashMap<>();
+        if (configAdmin != null) {
+            final Configuration c = configAdmin.getConfiguration(pid);
+            if (c != null) {
+                final Dictionary<String, Object> dict = c.getProperties();
+                if (dict != null) {
+                    final Enumeration<String> keys = dict.keys();
+                    while (keys.hasMoreElements()) {
+                        final String key = keys.nextElement();
+                        props.put(key, dict.get(key).toString());
+                    }
+                }
+            }
+        }
+
+        return props;
+    }
+}

--- a/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/HttpClientFactory.java
+++ b/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/HttpClientFactory.java
@@ -20,8 +20,6 @@ package org.fcrepo.apix.registry;
 
 import java.io.IOException;
 import java.util.Base64;
-import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,25 +92,13 @@ public class HttpClientFactory {
     }
 
     /**
-     * Set props as a dictionary, eww.
-     *
-     * @param dict Dictionaty
-     */
-    public void setDictionary(final Dictionary<String, Object> dict) {
-        props = new HashMap<>();
-        final Enumeration<String> keys = dict.keys();
-        while (keys.hasMoreElements()) {
-            final String key = keys.nextElement();
-            props.put(key, dict.get(key).toString());
-        }
-    }
-
-    /**
      * Construct a new HttpClient.
      *
      * @return HttpClient impl.
      */
     public CloseableHttpClient getClient() {
+
+        LOG.info("Creating client");
         final RequestConfig config = RequestConfig.custom()
                 .setConnectTimeout(connectTimeout)
                 .setSocketTimeout(socketTimeout).build();
@@ -129,7 +115,7 @@ public class HttpClientFactory {
                     authSpec.scheme), new UsernamePasswordCredentials(authSpec.username(), authSpec.passwd()));
         }
 
-        return HttpClientBuilder.create().setDefaultRequestConfig(config)
+        final CloseableHttpClient c = HttpClientBuilder.create().setDefaultRequestConfig(config)
                 .addInterceptorLast(new HttpRequestInterceptor() {
 
                     @Override
@@ -157,6 +143,9 @@ public class HttpClientFactory {
                 .setDefaultCredentialsProvider(
                         provider)
                 .build();
+
+        LOG.info("Returning client " + c);
+        return c;
     }
 
     List<AuthSpec> getAuthSpecs() {

--- a/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/HttpClientFactory.java
+++ b/fcrepo-api-x-registry/src/main/java/org/fcrepo/apix/registry/HttpClientFactory.java
@@ -98,7 +98,6 @@ public class HttpClientFactory {
      */
     public CloseableHttpClient getClient() {
 
-        LOG.info("Creating client");
         final RequestConfig config = RequestConfig.custom()
                 .setConnectTimeout(connectTimeout)
                 .setSocketTimeout(socketTimeout).build();
@@ -115,7 +114,7 @@ public class HttpClientFactory {
                     authSpec.scheme), new UsernamePasswordCredentials(authSpec.username(), authSpec.passwd()));
         }
 
-        final CloseableHttpClient c = HttpClientBuilder.create().setDefaultRequestConfig(config)
+        return HttpClientBuilder.create().setDefaultRequestConfig(config)
                 .addInterceptorLast(new HttpRequestInterceptor() {
 
                     @Override
@@ -143,9 +142,6 @@ public class HttpClientFactory {
                 .setDefaultCredentialsProvider(
                         provider)
                 .build();
-
-        LOG.info("Returning client " + c);
-        return c;
     }
 
     List<AuthSpec> getAuthSpecs() {

--- a/fcrepo-api-x-registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-registry/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,14 +19,17 @@
 
   <bean id="configAdmin" factory-ref="conf" factory-method="getConfigAdmin" />
 
-  <bean id="configuration" factory-ref="configAdmin"
-    factory-method="getConfiguration">
+  <bean id="configHelper" class="org.fcrepo.apix.registry.ConfigHelper">
+    <property name="configurationAdmin" ref="configAdmin" />
+  </bean>
+  
+  <bean id="configProperties" factory-ref="configHelper"
+    factory-method="getProperties">
     <argument value="org.fcrepo.apix.registry.http" />
   </bean>
 
-  <bean id="configDict" factory-ref="configuration" factory-method="getProperties" />
-
-  <reference-list id="httpClients" interface="org.apache.http.client.HttpClient" availability="optional">
+  <reference-list id="httpClients" interface="org.apache.http.client.HttpClient"
+    availability="optional">
     <reference-listener bind-method="bind"
       unbind-method="unbind" ref="httpClientFetcher">
     </reference-listener>
@@ -36,7 +39,7 @@
   <bean id="httpClientFactory" class="org.fcrepo.apix.registry.HttpClientFactory">
     <property name="connectTimeout" value="${timeout.connect.ms}" />
     <property name="socketTimeout" value="${timeout.socket.ms}" />
-    <property name="dictionary" ref="configDict" />
+    <property name="properties" ref="configProperties" />
   </bean>
 
   <bean id="httpClient-default" factory-ref="httpClientFactory"


### PR DESCRIPTION
The fcrepo-api-x registry mdule injectd a map of properties from
ConfigurationAdmin in blueprint.  This caused an NPE if the
configurationAdmin was undefined.  This commit adds some helper code to
make it optional.

Resolves #119 