### PR TITLE
Use injected HttpClient for loader

### DIFF
--- a/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.test.cfg
+++ b/fcrepo-api-x-integration/src/test/resources/cfg/org.fcrepo.apix.test.cfg
@@ -2,3 +2,5 @@ auth.http.${fcrepo.dynamic.test.port}.localhost.username = fedoraAdmin
 auth.http.${fcrepo.dynamic.test.port}.localhost.password = secret3
 auth.http.${apix.dynamic.test.port}.localhost.username = fedoraAdmin
 auth.http.${apix.dynamic.test.port}.localhost.password = secret3
+auth.http.${services.dynamic.test.port}.127.0.0.1.username = fedoraAdmin
+auth.http.${services.dynamic.test.port}.127.0.0.1.password = secret3

--- a/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderRoutes.java
+++ b/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderRoutes.java
@@ -125,7 +125,7 @@ public class LoaderRoutes extends RouteBuilder {
                 .setHeader(Exchange.HTTP_URI, header(HEADER_SERVICE_URI))
                 .setHeader("Accept", constant("text/turtle"))
                 .process(e -> LOG.info("Execution OPTIONS to service URI {}", e.getIn().getHeader(Exchange.HTTP_URI)))
-                .to("jetty:http://localhost")
+                .to("http://localhost?httpClient=#httpClient")
                 .process(DEPOSIT_OBJECTS)
                 .setHeader(HTTP_RESPONSE_CODE, constant(303));
 

--- a/fcrepo-api-x-loader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-loader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -22,6 +22,15 @@
     </cm:default-properties>
   </cm:property-placeholder>
 
+  <reference id="httpClientFetcher" ext:proxy-method="classes"
+    interface="org.fcrepo.apix.registry.HttpClientFetcher" />
+
+  <bean id="httpClient" factory-ref="httpClientFetcher"
+    factory-method="getClient" />
+
+  <bean id="http" class="org.apache.camel.component.http4.HttpComponent" />
+  <bean id="https" class="org.apache.camel.component.http4.HttpComponent" />
+
   <reference id="extensionRegistry"
     interface="org.fcrepo.apix.model.components.ExtensionRegistry" />
 
@@ -31,7 +40,8 @@
   <reference id="generalRegistry" filter="(org.fcrepo.apix.registry.role=default)"
     interface="org.fcrepo.apix.model.components.Registry" />
 
-  <reference id="routing" interface="org.fcrepo.apix.model.components.RoutingFactory" />
+  <reference id="routing"
+    interface="org.fcrepo.apix.model.components.RoutingFactory" />
 
   <bean id="loaderService" class="org.fcrepo.apix.loader.impl.LoaderService">
     <property name="extensionRegistry" ref="extensionRegistry" />


### PR DESCRIPTION
The loader's interaction with a service with respect to OPTIONS now occurs
through the registry HttpClient, which can be configured for
authentication

Resolves #121 