### PR TITLE
Don't bind extensions to inaccessible resources

### DIFF
--- a/fcrepo-api-x-binding/src/main/java/org/fcrepo/apix/binding/impl/RuntimeExtensionBinding.java
+++ b/fcrepo-api-x-binding/src/main/java/org/fcrepo/apix/binding/impl/RuntimeExtensionBinding.java
@@ -182,7 +182,13 @@ public class RuntimeExtensionBinding implements ExtensionBinding {
         // Use object contents for reasoning, or if binary the binary's description
         try (final CloseableHttpResponse response = httpClient.execute(new HttpHead(resourceURI))) {
 
-            if (response.getStatusLine().getStatusCode() != 200) {
+            final int status = response.getStatusLine().getStatusCode();
+            if (status > 399 && status < 500) {
+                LOG.info("Got status {} on {}, skipping extensions", status, resourceURI);
+                return Collections.emptyList();
+            }
+
+            if (status != 200) {
                 throw new RuntimeException(String.format("Got unexpected status code %s in HEAD to <%s>",
                         response.getStatusLine().getStatusCode(),
                         resourceURI));


### PR DESCRIPTION
If a HEAD request to a repository resource fails, bypass all extension
mechanisms.

Resolves #134