### PR TITLE
Upgrade to Camel 2.19.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.iws
 *.iml
 .idea
+.vscode/
 target/
 *.swp
 *.log

--- a/fcrepo-api-x-indexing/pom.xml
+++ b/fcrepo-api-x-indexing/pom.xml
@@ -43,6 +43,13 @@
       <version>${camel.version}</version>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-jackson</artifactId>
+      <version>${camel.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/fcrepo-api-x-indexing/src/test/java/org/fcrepo/apix/indexing/impl/ServiceIndexingRoutesTest.java
+++ b/fcrepo-api-x-indexing/src/test/java/org/fcrepo/apix/indexing/impl/ServiceIndexingRoutesTest.java
@@ -93,7 +93,7 @@ public class ServiceIndexingRoutesTest extends CamelBlueprintTestSupport {
 
     @Override
     public boolean isUseRouteBuilder() {
-        return false;
+        return true;
     }
 
     @Override
@@ -108,6 +108,10 @@ public class ServiceIndexingRoutesTest extends CamelBlueprintTestSupport {
 
     @Before
     public void init() throws Exception {
+
+        // For some reason, this is necessary after upgrating to Camel 2.19.
+        // Otherwise, it looks like the context doesn't start(!??)
+        context.start();
         dataset = DatasetFactory.create();
 
         // Create two named graphs with triples. Verify that they're non-empty from the start.

--- a/fcrepo-api-x-indexing/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
+++ b/fcrepo-api-x-indexing/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
@@ -45,7 +45,7 @@
     <routeBuilder ref="indexerRoutes" />
   </camelContext>
 
-  <service interface="org.apache.camel.CamelContext" ref="FcrepoServiceIndexer">
+  <service interface="org.apache.camel.model.ModelCamelContext" ref="FcrepoServiceIndexer">
     <service-properties>
       <entry key="role" value="FcrepoServiceIndexer" />
     </service-properties>

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/LoaderIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/LoaderIT.java
@@ -343,7 +343,6 @@ public class LoaderIT extends ServiceBasedTest {
     private final FcrepoResponse textPost(final String uri, final String content) throws Exception {
 
         final String body = content;
-
         return client.post(URI.create(uri)).body(new ByteArrayInputStream(body.getBytes()),
                 "text/plain").perform();
     }

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceBasedTest.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceBasedTest.java
@@ -132,8 +132,9 @@ public abstract class ServiceBasedTest implements KarafIT {
 
             @Override
             public void configure() throws Exception {
+
                 from("jetty:" + serviceEndpoint +
-                        "?matchOnUriPrefix=true")
+                        "?matchOnUriPrefix=true&optionsEnabled=true")
                                 .routeId(SERVICE_ROUTE_ID)
                                 .process(ex -> {
                                     requestToService.copyFrom(ex.getIn());

--- a/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceDocumentIT.java
+++ b/fcrepo-api-x-integration/src/test/java/org/fcrepo/apix/integration/ServiceDocumentIT.java
@@ -18,6 +18,7 @@
 
 package org.fcrepo.apix.integration;
 
+import static org.fcrepo.apix.integration.KarafIT.attempt;
 import static org.fcrepo.apix.jena.Util.parse;
 import static org.fcrepo.apix.model.Ontologies.RDF_TYPE;
 import static org.fcrepo.apix.model.Ontologies.Service.CLASS_SERVICE_INSTANCE;
@@ -33,9 +34,9 @@ import javax.inject.Inject;
 import org.fcrepo.apix.model.WebResource;
 import org.fcrepo.apix.model.components.ExtensionRegistry;
 import org.fcrepo.apix.model.components.Registry;
+import org.fcrepo.apix.model.components.RoutingFactory;
 
 import org.apache.jena.rdf.model.Model;
-import org.fcrepo.apix.model.components.RoutingFactory;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,7 +86,7 @@ public class ServiceDocumentIT implements KarafIT {
     public void emptyServiceDocumentTest() throws Exception {
 
         final URI object = routing.of(REQUEST_URI).interceptUriFor(serviceContainer);
-        final URI serviceDocURI = client.head(object).perform().getLinkHeaders("service").get(0);
+        final URI serviceDocURI = attempt(60, () -> client.head(object).perform().getLinkHeaders("service").get(0));
 
         try (WebResource resource = repository.get(serviceDocURI)) {
             final Model doc = parse(resource);
@@ -108,7 +109,7 @@ public class ServiceDocumentIT implements KarafIT {
 
         final URI container = routing.of(REQUEST_URI).interceptUriFor(objectContainer);
 
-        final URI object = postFromTestResource("objects/object_serviceDocumentIT.ttl", container);
+        final URI object = attempt(60, () -> postFromTestResource("objects/object_serviceDocumentIT.ttl", container));
 
         final URI serviceDocURI = client.head(object).perform().getLinkHeaders("service").get(0);
 

--- a/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderService.java
+++ b/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderService.java
@@ -140,9 +140,9 @@ public class LoaderService {
                     WebResource.of(new ByteArrayInputStream(body), resource.contentType()));
         } else {
             throw new RuntimeException(String.format(
-                    "Cannot load resource.  Does not describe exactly one extension (%d), " +
+                    "Cannot load resource <%s>.  Does not describe exactly one extension (%d), " +
                             "or define any services:\n===\n%s\n===",
-                    extensionCount, new String(body)));
+                    resource.uri(), extensionCount, new String(body)));
         }
 
         // Now, see if we need to register a service instance.

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/GenericInterceptExecution.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/GenericInterceptExecution.java
@@ -27,10 +27,12 @@ import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.fcrepo.apix.model.Extension;
@@ -43,7 +45,6 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.processor.aggregate.AggregationStrategy;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,7 +121,7 @@ public class GenericInterceptExecution extends RouteBuilder implements Updateabl
         this.proxyURI = uri;
     }
 
-    private final Collection<Extension> extensions = new ConcurrentHashSet<>();
+    private final Collection<Extension> extensions = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     @Override
     public void update() {

--- a/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
+++ b/fcrepo-api-x-routing/src/main/java/org/fcrepo/apix/routing/impl/RoutingImpl.java
@@ -174,14 +174,16 @@ public class RoutingImpl extends RouteBuilder {
 
         // It would be nice to use the rest DSL to do the service doc, if that is at all possible
 
-        from("jetty:http://{{apix.listen.host}}:{{apix.port}}/{{apix.discoveryPath}}?matchOnUriPrefix=true")
-                .routeId("service-doc-endpoint")
-                .process(WRITE_SERVICE_DOC);
+        from("jetty:http://{{apix.listen.host}}:{{apix.port}}/{{apix.discoveryPath}}" +
+                "?matchOnUriPrefix=true&optionsEnabled=true")
+                        .routeId("service-doc-endpoint")
+                        .process(WRITE_SERVICE_DOC);
 
         from("jetty:http://{{apix.listen.host}}:{{apix.port}}/{{apix.exposePath}}" +
                 "?matchOnUriPrefix=true" +
                 "&bridgeEndpoint=true" +
-                "&disableStreamCache=true")
+                "&disableStreamCache=true" +
+                "&optionsEnabled=true")
                         .routeId("endpoint-expose").routeDescription("Endpoint for exposed service mediation")
                         .process(ANALYZE_URI)
                         .choice()
@@ -191,7 +193,8 @@ public class RoutingImpl extends RouteBuilder {
         from("jetty:http://{{apix.listen.host}}:{{apix.port}}/{{apix.proxyPath}}?" +
                 "matchOnUriPrefix=true" +
                 "&bridgeEndpoint=true" +
-                "&disableStreamCache=true")
+                "&disableStreamCache=true" +
+                "&optionsEnabled=true")
                         .routeId("endpoint-proxy").routeDescription("Endpoint for proxy to Fedora")
 
                         .choice()

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <activemq.version>5.14.5</activemq.version>
-    <camel.version>2.18.4</camel.version>
+    <camel.version>2.19.2</camel.version>
     <cargo.version>1.6.3</cargo.version>
     <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
     <commons-io.version>2.5</commons-io.version>
@@ -108,7 +108,7 @@
         <plugin>
           <groupId>org.apache.karaf.tooling</groupId>
           <artifactId>karaf-maven-plugin</artifactId>
-          <version>${karaf.version}</version>
+          <version>4.0.9</version>
           <extensions>true</extensions>
           <executions>
             <execution>


### PR DESCRIPTION
Fix all subtle breakages that were introduced aling the way.  This appears
to also result in a clean build with Karaf 4.1.x, albeit with a different
Jetty implementation in 4.0.x vs 4.1.x.  Numerous small but difficult
incompatibilities were fixed along the way:

- BlueprintTestSupport expects a specific CamelContext class from OSGi

- For some reason, the lifecycle of the CamelContext used by
  BlueprintTestSupport doesn't automatically start the context

- Jetty silently discards OPTIONS requests unless explicitly given an
  option to enable OPTIONS

- The Karaf 4.1.x features maven plugin doesn't work.

Resolves #140 