### PR TITLE
Add explicit dependency on fcrepo-java-client 0.3.0

### DIFF
--- a/fcrepo-api-x-indexing/pom.xml
+++ b/fcrepo-api-x-indexing/pom.xml
@@ -31,6 +31,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.fcrepo.client</groupId>
+      <artifactId>fcrepo-java-client</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.fcrepo.camel</groupId>
       <artifactId>fcrepo-camel</artifactId>
       <version>${fcrepo-camel.version}</version>


### PR DESCRIPTION
Add explicit dependency on fcrepo-java-client 0.3.0, properly provisoning the dependency as a Karaf feature.

Closes #143