### PR TITLE
Enable OPTIONS for loader camel Route

### DIFF
--- a/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderRoutes.java
+++ b/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderRoutes.java
@@ -91,7 +91,10 @@ public class LoaderRoutes extends RouteBuilder {
     public void configure() throws Exception {
 
         from("jetty:http://0.0.0.0:{{loader.port}}/load" +
-                "?matchOnUriPrefix=true&sendServerVersion=false&httpMethodRestrict=GET,OPTIONS,POST")
+                "?matchOnUriPrefix=true" +
+                "&sendServerVersion=false" +
+                "&httpMethodRestrict=GET,OPTIONS,POST" +
+                "&optionsEnabled=true")
                         .id("loader-http")
                         .choice()
 


### PR DESCRIPTION
The Camel 2.19.x jetty component fails too pass OPTIONS requests to the
routes by default.  This fixes that for the loader extension.

Resolves #146 