### PR TITLE
replaces "localhost" and "0.0.0.0" in load-extension route

### DIFF
--- a/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderRoutes.java
+++ b/fcrepo-api-x-loader/src/main/java/org/fcrepo/apix/loader/impl/LoaderRoutes.java
@@ -90,7 +90,7 @@ public class LoaderRoutes extends RouteBuilder {
     @Override
     public void configure() throws Exception {
 
-        from("jetty:http://0.0.0.0:{{loader.port}}/load" +
+        from("jetty:http://{{loader.host}}:{{loader.port}}/load" +
                 "?matchOnUriPrefix=true" +
                 "&sendServerVersion=false" +
                 "&httpMethodRestrict=GET,OPTIONS,POST" +

--- a/fcrepo-api-x-loader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-api-x-loader/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -75,13 +75,13 @@
         <constant>POST</constant>
       </setHeader>
       <setBody>
-        <simple>http://localhost:{{loader.port}}/load</simple>
+        <simple>http://{{loader.host}}:{{loader.port}}/load</simple>
       </setBody>
       <choice>
         <when>
           <simple>{{extension.load}}</simple>
           <to
-            uri="jetty:http://localhost:{{loader.port}}/load?okStatusCodeRange=200-399" />
+            uri="jetty:http://{{loader.host}}:{{loader.port}}/load?okStatusCodeRange=200-399" />
         </when>
       </choice>
     </route>


### PR DESCRIPTION
The blueprint configuration variable {{loader.host}} is not used.   The loader host should be configurable esp. for dockerization.